### PR TITLE
feat: Add comprehensive workout history map viewer with detailed stats

### DIFF
--- a/rythmrun_frontend_flutter/lib/presentation/features/tracking_history/screens/tracking_history_details_screen.dart
+++ b/rythmrun_frontend_flutter/lib/presentation/features/tracking_history/screens/tracking_history_details_screen.dart
@@ -1,0 +1,297 @@
+import 'package:flutter/material.dart';
+import 'package:rythmrun_frontend_flutter/domain/entities/workout_session_entity.dart';
+import 'package:rythmrun_frontend_flutter/presentation/features/Map/screens/live_map_feed_helper.dart';
+import 'package:rythmrun_frontend_flutter/presentation/features/tracking_history/screens/workout_history_map_viewer.dart';
+import 'package:rythmrun_frontend_flutter/theme/app_theme.dart';
+
+class TrackingHistoryDetailsScreen extends StatefulWidget {
+  final WorkoutSessionEntity workout;
+
+  const TrackingHistoryDetailsScreen({super.key, required this.workout});
+
+  @override
+  State<TrackingHistoryDetailsScreen> createState() =>
+      _TrackingHistoryDetailsScreenState();
+}
+
+class _TrackingHistoryDetailsScreenState
+    extends State<TrackingHistoryDetailsScreen> {
+  bool _showMapTiles = true;
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Workout Details'),
+        elevation: 0,
+        leading: IconButton(
+          onPressed: () => Navigator.pop(context),
+          icon: const Icon(Icons.arrow_back),
+        ),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Map view
+                Container(
+                  height: 400,
+                  child: WorkoutHistoryMapViewer(
+                    workout: widget.workout,
+                    showMapTiles: _showMapTiles,
+                    showControls: true,
+                  ),
+                ),
+
+                const SizedBox(height: 20),
+                _buildComprehensiveStats(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildComprehensiveStats() {
+    final duration =
+        widget.workout.endTime != null && widget.workout.startTime != null
+            ? widget.workout.endTime!.difference(widget.workout.startTime!)
+            : Duration.zero;
+
+    final activeDuration = widget.workout.activeDuration ?? duration;
+    final pausedDuration = widget.workout.pausedDuration ?? Duration.zero;
+    final totalDuration = activeDuration + pausedDuration;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(spacingLg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  getCurrentLocationIcon(widget.workout),
+                  color: getWorkoutColor(widget.workout.type),
+                  size: iconSizeLg,
+                ),
+                const SizedBox(width: spacingMd),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      _getWorkoutTypeString(widget.workout.type),
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    Text(
+                      _formatFullDate(widget.workout.startTime),
+                      style: Theme.of(
+                        context,
+                      ).textTheme.bodyMedium?.copyWith(color: Colors.grey[600]),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+
+            const SizedBox(height: spacingLg),
+
+            // Main stats row
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                _buildStatColumn(
+                  'Distance',
+                  '${(widget.workout.totalDistance / 1000).toStringAsFixed(2)} km',
+                  Icons.route,
+                ),
+
+                _buildStatColumn(
+                  'Avg Pace',
+                  _formatPace(widget.workout.averagePace),
+                  Icons.trending_up,
+                ),
+              ],
+            ),
+
+            const SizedBox(height: spacingLg),
+
+            // Secondary stats row
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                _buildStatColumn(
+                  'Total Time',
+                  _formatDuration(totalDuration),
+                  Icons.play_arrow,
+                ),
+                _buildStatColumn(
+                  'Active Time',
+                  _formatDuration(activeDuration),
+                  Icons.play_arrow,
+                ),
+              ],
+            ),
+
+            const SizedBox(height: spacingLg),
+
+            // Time details row
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                _buildStatColumn(
+                  'Start Time',
+                  _formatTime(widget.workout.startTime),
+                  Icons.play_circle_outline,
+                ),
+                _buildStatColumn(
+                  'End Time',
+                  _formatTime(widget.workout.endTime),
+                  Icons.stop_circle_outlined,
+                ),
+              ],
+            ),
+
+            // Additional stats if available
+            if (widget.workout.elevationGain != null &&
+                    widget.workout.elevationGain! > 0 ||
+                widget.workout.calories != null) ...[
+              const SizedBox(height: spacingLg),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  if (widget.workout.elevationGain != null &&
+                      widget.workout.elevationGain! > 0) ...[
+                    _buildStatColumn(
+                      'Elevation',
+                      '${widget.workout.elevationGain!.toInt()}m',
+                      Icons.terrain,
+                    ),
+                  ],
+                  if (widget.workout.calories != null) ...[
+                    _buildStatColumn(
+                      'Calories',
+                      '${widget.workout.calories}',
+                      Icons.local_fire_department,
+                    ),
+                  ],
+                ],
+              ),
+            ],
+
+            // Notes if available
+            if (widget.workout.notes != null &&
+                widget.workout.notes!.isNotEmpty) ...[
+              const SizedBox(height: spacingLg),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(spacingMd),
+                decoration: BoxDecoration(
+                  color: Colors.grey[100],
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.note, size: 16, color: Colors.grey),
+                        const SizedBox(width: spacingSm),
+                        Text(
+                          'Notes',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.grey[700],
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: spacingSm),
+                    Text(
+                      widget.workout.notes!,
+                      style: const TextStyle(fontSize: 14),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatColumn(String label, String value, IconData icon) {
+    return Column(
+      children: [
+        Icon(icon, size: 20, color: Colors.grey[600]),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+        ),
+        const SizedBox(height: 2),
+        Text(label, style: TextStyle(color: Colors.grey[600], fontSize: 12)),
+      ],
+    );
+  }
+
+  String _formatTime(DateTime? time) {
+    if (time == null) return 'N/A';
+    return '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
+  }
+
+  String _formatFullDate(DateTime? date) {
+    if (date == null) return 'Unknown date';
+
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final yesterday = today.subtract(const Duration(days: 1));
+    final dateOnly = DateTime(date.year, date.month, date.day);
+
+    if (dateOnly == today) {
+      return 'Today at ${_formatTime(date)}';
+    } else if (dateOnly == yesterday) {
+      return 'Yesterday at ${_formatTime(date)}';
+    } else {
+      return '${date.day}/${date.month}/${date.year} at ${_formatTime(date)}';
+    }
+  }
+
+  String _formatDuration(Duration duration) {
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes % 60;
+    final seconds = duration.inSeconds % 60;
+
+    if (hours > 0) {
+      return '${hours}h ${minutes}m';
+    } else if (minutes > 0) {
+      return '${minutes}m ${seconds}s';
+    } else {
+      return '${seconds}s';
+    }
+  }
+
+  String _formatPace(double? pace) {
+    if (pace == null || pace == 0) return '--:--';
+    final minutes = pace.floor();
+    final seconds = ((pace - minutes) * 60).round();
+    return '${minutes}:${seconds.toString().padLeft(2, '0')} /km';
+  }
+
+  int _getSegmentCount() {
+    // This would use the segment builder to count segments
+    // For now, return a placeholder
+    return widget.workout.statusChanges?.length ?? 1;
+  }
+
+  String _getWorkoutTypeString(WorkoutType type) {
+    return type.name[0].toUpperCase() + type.name.substring(1);
+  }
+}

--- a/rythmrun_frontend_flutter/lib/presentation/features/tracking_history/screens/tracking_history_screen.dart
+++ b/rythmrun_frontend_flutter/lib/presentation/features/tracking_history/screens/tracking_history_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:rythmrun_frontend_flutter/const/custom_app_colors.dart';
 import 'package:rythmrun_frontend_flutter/domain/entities/workout_session_entity.dart';
 import 'package:rythmrun_frontend_flutter/presentation/features/tracking_history/models/tracking_history_state.dart';
+import 'package:rythmrun_frontend_flutter/presentation/features/tracking_history/screens/tracking_history_details_screen.dart';
 import 'package:rythmrun_frontend_flutter/theme/app_theme.dart';
 import '../providers/tracking_history_provider.dart';
 
@@ -141,11 +142,10 @@ class ActivitiesScreen extends ConsumerWidget {
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
         onTap: () {
-          // TODO: Navigate to workout details screen
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Tracking details coming soon!'),
-              duration: Duration(seconds: 1),
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder:
+                  (context) => TrackingHistoryDetailsScreen(workout: workout),
             ),
           );
         },

--- a/rythmrun_frontend_flutter/lib/presentation/features/tracking_history/screens/workout_history_map_viewer.dart
+++ b/rythmrun_frontend_flutter/lib/presentation/features/tracking_history/screens/workout_history_map_viewer.dart
@@ -1,0 +1,337 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:rythmrun_frontend_flutter/const/custom_app_colors.dart';
+import 'package:rythmrun_frontend_flutter/domain/entities/workout_session_entity.dart';
+import 'package:rythmrun_frontend_flutter/presentation/common/widgets/map_controller_button.dart';
+import 'package:rythmrun_frontend_flutter/presentation/features/Map/screens/live_map_feed_helper.dart';
+import 'package:rythmrun_frontend_flutter/presentation/features/Map/screens/live_map_segment_builder.dart';
+import 'package:rythmrun_frontend_flutter/theme/app_theme.dart';
+
+class WorkoutHistoryMapViewer extends StatefulWidget {
+  final WorkoutSessionEntity workout;
+  final bool showMapTiles;
+  final bool showControls;
+
+  const WorkoutHistoryMapViewer({
+    super.key,
+    required this.workout,
+    this.showMapTiles = true,
+    this.showControls = true,
+  });
+
+  @override
+  State<WorkoutHistoryMapViewer> createState() =>
+      _WorkoutHistoryMapViewerState();
+}
+
+class _WorkoutHistoryMapViewerState extends State<WorkoutHistoryMapViewer> {
+  MapController? _mapController;
+  final List<Marker> _markers = [];
+  final List<Polyline> _solidPolylines = [];
+  final List<Polyline> _dashedPolylines = [];
+  bool _showMapTiles = true;
+
+  // Default camera position
+  LatLng _center = const LatLng(37.4419, -122.1419);
+  double _zoom = 16.0;
+
+  @override
+  void initState() {
+    super.initState();
+    setState(() {
+      _showMapTiles = widget.showMapTiles;
+    });
+    _initializeMap();
+  }
+
+  void _initializeMap() {
+    _mapController = MapController();
+
+    if (widget.workout.trackingPoints.isNotEmpty) {
+      // Center map on workout start location
+      final startPoint = widget.workout.trackingPoints.first;
+      _center = LatLng(startPoint.latitude, startPoint.longitude);
+
+      _buildWorkoutVisualization();
+
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _fitWorkoutToMap();
+      });
+    }
+  }
+
+  void _buildWorkoutVisualization() {
+    print(
+      '🔧 Building workout visualization for ${widget.workout.trackingPoints.length} points',
+    );
+
+    _markers.clear();
+    _solidPolylines.clear();
+    _dashedPolylines.clear();
+
+    if (widget.workout.trackingPoints.isEmpty) return;
+
+    // Build segments from workout data
+    final segments = LiveMapSegmentBuilder.buildSegments(widget.workout);
+
+    print('🎯 Built ${segments.length} segments for visualization');
+
+    // Create polylines for each segment
+    for (final segment in segments) {
+      if (segment.points.length < 2) continue;
+
+      final points =
+          segment.points
+              .map((point) => LatLng(point.latitude, point.longitude))
+              .toList();
+
+      if (segment.status == WorkoutStatus.active) {
+        _createSolidPolyline(points, widget.workout.type);
+      } else if (segment.status == WorkoutStatus.paused) {
+        _createDashedPolyline(points, widget.workout.type);
+      }
+    }
+
+    // Add start and end markers
+    _addStartMarker();
+    _addEndMarker();
+
+    setState(() {});
+  }
+
+  void _createSolidPolyline(List<LatLng> points, WorkoutType type) {
+    final polyline = Polyline(
+      points: points,
+      color: getWorkoutColor(type),
+      strokeWidth: 4,
+      strokeCap: StrokeCap.round,
+      strokeJoin: StrokeJoin.round,
+    );
+    _solidPolylines.add(polyline);
+  }
+
+  void _createDashedPolyline(List<LatLng> points, WorkoutType type) {
+    final polyline = Polyline(
+      points: points,
+      color: CustomAppColors.statusError,
+      strokeWidth: 4,
+      strokeCap: StrokeCap.round,
+      strokeJoin: StrokeJoin.round,
+      pattern: StrokePattern.dashed(segments: [10, 5]),
+    );
+    _dashedPolylines.add(polyline);
+  }
+
+  void _addStartMarker() {
+    if (widget.workout.trackingPoints.isEmpty) return;
+
+    final startPoint = widget.workout.trackingPoints.first;
+    final startMarker = Marker(
+      key: const ValueKey('start_marker'),
+      point: LatLng(startPoint.latitude, startPoint.longitude),
+      width: 30,
+      height: 30,
+      child: Container(
+        decoration: BoxDecoration(
+          color: CustomAppColors.statusSuccess,
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.white, width: 3),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.3),
+              blurRadius: 6,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: const Icon(Icons.play_arrow, color: Colors.white, size: 20),
+      ),
+    );
+    _markers.add(startMarker);
+  }
+
+  void _addEndMarker() {
+    if (widget.workout.trackingPoints.isEmpty) return;
+
+    final endPoint = widget.workout.trackingPoints.last;
+    final endMarker = Marker(
+      key: const ValueKey('end_marker'),
+      point: LatLng(endPoint.latitude, endPoint.longitude),
+      width: 30,
+      height: 30,
+      child: Container(
+        decoration: BoxDecoration(
+          color: CustomAppColors.statusError,
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.white, width: 3),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.3),
+              blurRadius: 6,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: const Icon(stopIcon, color: Colors.white, size: 15),
+      ),
+    );
+    _markers.add(endMarker);
+  }
+
+  void _fitWorkoutToMap() {
+    if (widget.workout.trackingPoints.isEmpty || _mapController == null) return;
+
+    // Calculate bounds for all tracking points
+    double minLat = widget.workout.trackingPoints.first.latitude;
+    double maxLat = widget.workout.trackingPoints.first.latitude;
+    double minLng = widget.workout.trackingPoints.first.longitude;
+    double maxLng = widget.workout.trackingPoints.first.longitude;
+
+    for (final point in widget.workout.trackingPoints) {
+      minLat = minLat < point.latitude ? minLat : point.latitude;
+      maxLat = maxLat > point.latitude ? maxLat : point.latitude;
+      minLng = minLng < point.longitude ? minLng : point.longitude;
+      maxLng = maxLng > point.longitude ? maxLng : point.longitude;
+    }
+
+    final bounds = LatLngBounds(LatLng(minLat, minLng), LatLng(maxLat, maxLng));
+
+    _mapController!.fitCamera(
+      CameraFit.bounds(bounds: bounds, padding: const EdgeInsets.all(50)),
+    );
+  }
+
+  void _toggleMapTiles() {
+    setState(() {
+      _showMapTiles = !_showMapTiles;
+    });
+  }
+
+  void _centerOnStart() {
+    if (widget.workout.trackingPoints.isNotEmpty && _mapController != null) {
+      final startPoint = widget.workout.trackingPoints.first;
+      _mapController!.move(
+        LatLng(startPoint.latitude, startPoint.longitude),
+        _zoom,
+      );
+    }
+  }
+
+  void _centerOnEnd() {
+    if (widget.workout.trackingPoints.isNotEmpty && _mapController != null) {
+      final endPoint = widget.workout.trackingPoints.last;
+      _mapController!.move(
+        LatLng(endPoint.latitude, endPoint.longitude),
+        _zoom,
+      );
+    }
+  }
+
+  void _zoomIn() {
+    final currentZoom = _mapController?.camera.zoom ?? _zoom;
+    _mapController?.move(_mapController!.camera.center, currentZoom + 1);
+  }
+
+  void _zoomOut() {
+    final currentZoom = _mapController?.camera.zoom ?? _zoom;
+    _mapController?.move(_mapController!.camera.center, currentZoom - 1);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(radiusLg),
+        color:
+            _showMapTiles
+                ? Colors.transparent
+                : (Colors.grey[100] ?? Colors.grey),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(radiusLg),
+        child: Stack(
+          children: [
+            FlutterMap(
+              mapController: _mapController,
+              options: MapOptions(
+                initialCenter: _center,
+                initialZoom: _zoom,
+                minZoom: 3,
+                maxZoom: 19,
+                backgroundColor:
+                    _showMapTiles
+                        ? Colors.transparent
+                        : (Colors.grey[100] ?? Colors.grey),
+              ),
+              children: [
+                // Map tiles (optional)
+                if (_showMapTiles)
+                  TileLayer(
+                    urlTemplate:
+                        'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    userAgentPackageName:
+                        'com.example.rythmrun_frontend_flutter',
+                    maxZoom: 19,
+                  ),
+
+                // Polylines
+                PolylineLayer(polylines: _solidPolylines),
+                PolylineLayer(polylines: _dashedPolylines),
+
+                // Markers
+                MarkerLayer(markers: _markers),
+              ],
+            ),
+
+            // Map controls
+            if (widget.showControls)
+              Positioned(
+                bottom: spacingMd,
+                right: spacingMd,
+                child: Column(
+                  children: [
+                    buildMapControlButton(
+                      icon: _showMapTiles ? Icons.layers_clear : Icons.layers,
+                      onPressed: _toggleMapTiles,
+                      tooltip: _showMapTiles ? 'Hide map' : 'Show map',
+                    ),
+                    const SizedBox(height: spacingSm),
+                    buildMapControlButton(
+                      icon: Icons.fit_screen,
+                      onPressed: _fitWorkoutToMap,
+                      tooltip: 'Fit workout',
+                    ),
+                    const SizedBox(height: spacingSm),
+                    buildMapControlButton(
+                      icon: Icons.play_arrow,
+                      onPressed: _centerOnStart,
+                      tooltip: 'Go to start',
+                    ),
+                    const SizedBox(height: spacingSm),
+                    buildMapControlButton(
+                      icon: Icons.stop,
+                      onPressed: _centerOnEnd,
+                      tooltip: 'Go to end',
+                    ),
+                    const SizedBox(height: spacingSm),
+                    buildMapControlButton(
+                      icon: Icons.zoom_in,
+                      onPressed: _zoomIn,
+                      tooltip: 'Zoom in',
+                    ),
+                    const SizedBox(height: spacingSm),
+                    buildMapControlButton(
+                      icon: Icons.zoom_out,
+                      onPressed: _zoomOut,
+                      tooltip: 'Zoom out',
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/rythmrun_frontend_flutter/lib/theme/app_theme.dart
+++ b/rythmrun_frontend_flutter/lib/theme/app_theme.dart
@@ -34,6 +34,8 @@ const double spacingSm = 8;
 
 /// - [md] 12px
 const double spacingMd = 12;
+
+/// - [lg] 16px
 const double spacingLg = 16;
 
 /// - [xl] 24px


### PR DESCRIPTION
- Add WorkoutHistoryMapViewer widget for displaying historical workout routes
- Implement segment-based polyline rendering (solid for active, dashed for paused)
- Add start/end markers with visual distinction
- Create comprehensive stats card with all workout details
- Add map tile toggle functionality
- Update navigation to pass workout data to details screen
- Show distance, duration, pace, timing, and optional elevation/calories
- Support route-only view without map tiles