### PR TITLE
refactor(error-handling): Centralize error display in LiveMapFeed

### DIFF
--- a/rythmrun_frontend_flutter/lib/presentation/features/Map/screens/live_map_feed.dart
+++ b/rythmrun_frontend_flutter/lib/presentation/features/Map/screens/live_map_feed.dart
@@ -44,6 +44,18 @@ class _LiveMapFeedState extends ConsumerState<LiveMapFeed> {
     _initializeMap();
   }
 
+  void _showErrorSnackBar(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: CustomAppColors.statusError,
+        behavior: SnackBarBehavior.floating,
+        margin: const EdgeInsets.all(spacingMd),
+      ),
+    );
+  }
+
   @override
   void dispose() {
     _locationSubscription?.cancel();
@@ -373,6 +385,17 @@ class _LiveMapFeedState extends ConsumerState<LiveMapFeed> {
       builder: (context, ref, child) {
         final liveTrackingState = ref.watch(liveTrackingProvider);
 
+        // Listen for error messages and show them in a SnackBar
+        ref.listen<String?>(
+          liveTrackingProvider.select((state) => state.errorMessage),
+          (previous, next) {
+            if (next != null) {
+              _showErrorSnackBar(next);
+              ref.read(liveTrackingProvider.notifier).clearErrorMessage();
+            }
+          },
+        );
+
         // Check for session state changes
         _handleSessionStateChanges(liveTrackingState.currentSession);
 
@@ -475,31 +498,7 @@ class _LiveMapFeedState extends ConsumerState<LiveMapFeed> {
                     ),
                   ),
 
-                // Error overlay
-                if (liveTrackingState.errorMessage != null)
-                  Positioned(
-                    bottom: spacingMd,
-                    left: spacingMd,
-                    right: spacingXl * 3,
-                    child: Card(
-                      color: CustomAppColors.statusError,
-                      child: Padding(
-                        padding: const EdgeInsets.all(spacingSm),
-                        child: Row(
-                          children: [
-                            Icon(Icons.error, color: CustomAppColors.white),
-                            const SizedBox(width: spacingSm),
-                            Expanded(
-                              child: Text(
-                                liveTrackingState.errorMessage!,
-                                style: TextStyle(color: CustomAppColors.white),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
+                // Error overlay is now handled by the SnackBar
               ],
             ),
           ),

--- a/rythmrun_frontend_flutter/lib/presentation/features/live_tracking/models/live_tracking_state.dart
+++ b/rythmrun_frontend_flutter/lib/presentation/features/live_tracking/models/live_tracking_state.dart
@@ -32,6 +32,7 @@ class LiveTrackingState {
     bool? isTracking,
     bool? isLoading,
     String? errorMessage,
+    bool? clearErrorMessage,
     TrackingPointEntity? currentLocation,
     Duration? elapsedTime,
     double? currentPace,
@@ -42,7 +43,8 @@ class LiveTrackingState {
       currentSession: currentSession ?? this.currentSession,
       isTracking: isTracking ?? this.isTracking,
       isLoading: isLoading ?? this.isLoading,
-      errorMessage: errorMessage ?? this.errorMessage,
+      errorMessage:
+          clearErrorMessage == true ? null : errorMessage ?? this.errorMessage,
       currentLocation: currentLocation ?? this.currentLocation,
       elapsedTime: elapsedTime ?? this.elapsedTime,
       currentPace: currentPace ?? this.currentPace,
@@ -55,7 +57,7 @@ class LiveTrackingState {
 
   /// Clear error message
   LiveTrackingState clearError() {
-    return copyWith(errorMessage: null);
+    return copyWith(clearErrorMessage: true);
   }
 
   ////----------------------Checkers----------------------

--- a/rythmrun_frontend_flutter/lib/presentation/features/live_tracking/providers/live_tracking_provider.dart
+++ b/rythmrun_frontend_flutter/lib/presentation/features/live_tracking/providers/live_tracking_provider.dart
@@ -31,6 +31,10 @@ class LiveTrackingNotifier extends StateNotifier<LiveTrackingState> {
     this._ref,
   ) : super(const LiveTrackingState());
 
+  void clearErrorMessage() {
+    state = state.copyWith(clearErrorMessage: true);
+  }
+
   /// Check location permissions
   Future<void> checkPermissions() async {
     try {

--- a/rythmrun_frontend_flutter/lib/presentation/features/live_tracking/screens/track_screen.dart
+++ b/rythmrun_frontend_flutter/lib/presentation/features/live_tracking/screens/track_screen.dart
@@ -193,9 +193,6 @@ class _TrackScreenState extends ConsumerState<TrackScreen>
                   ),
                 ),
 
-              if (liveTrackingState.errorMessage != null)
-                Text(liveTrackingState.errorMessage!),
-
               // Quick Actions (hidden when card is expanded)
             ],
           ),


### PR DESCRIPTION
- Removed the persistent error card from the map view.
- Implemented a SnackBar notification for error messages using ref.listen.
- The UI now calls clearErrorMessage() after displaying an error, ensuring it is only shown once.