### PR TITLE
chore(infra): migrate from AWS S3/CloudFront to Cloudflare R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ RythmRun combines an Android-first Flutter client with a TypeScript modular mono
 | Deleting or replacing media can fail halfway through | Delete tombstones, persisted retry timestamps, stale-operation recovery, idempotent confirmation, and upload-new-before-delete-old semantics preserve intent | Server cleanup currently uses a process-local retry loop rather than a leased job queue |
 | Account changes can race queued user-scoped work | Riverpod-wired operation gates drain synchronization, image, and profile work before credentials and providers are cleared | The current isolation work is unit-tested; device and staging verification remain release gates |
 
-Other high-signal details include versioned metric contracts across SQLite and PostgreSQL, SQL-backed history aggregation, server-issued storage keys, signed CloudFront reads, strict user/avatar DTO allowlists, fail-closed environment validation, and a testable backend bootstrap with no listener side effects.
+Other high-signal details include versioned metric contracts across SQLite and PostgreSQL, SQL-backed history aggregation, server-issued storage keys, signed R2 reads, strict user/avatar DTO allowlists, fail-closed environment validation, and a testable backend bootstrap with no listener side effects.
 
 ## Architecture
 
@@ -57,7 +57,7 @@ flowchart LR
 
     REPOS -->|Presigned PUT / POST| S3[(Amazon S3)]
     STORAGE --> S3
-    S3 --> CF[CloudFront]
+    R2[Cloudflare R2]
     CF -->|Short-lived signed reads| REPOS
 ```
 
@@ -78,14 +78,14 @@ Synchronization is intentionally tied to app-observable events: workout completi
 
 The backend is a strict-TypeScript Express modular monolith with route, middleware, controller, service, DTO, and Prisma boundaries. This keeps transactions and deployment topology simple while the workload does not justify microservices, Kafka, Redis, or Kubernetes.
 
-`createApp` is separate from listener and retry-loop startup, which makes HTTP-boundary tests deterministic. Startup validates database, JWT, AWS, S3, and CloudFront configuration before infrastructure clients are constructed. Core user, activity, image, and avatar services share a TSyringe-managed Prisma client; older social modules have not yet completed that migration and are intentionally not part of the highlighted system.
+`createApp` is separate from listener and retry-loop startup, which makes HTTP-boundary tests deterministic. Startup validates database, JWT, and R2 configuration before infrastructure clients are constructed. Core user, activity, image, and avatar services share a TSyringe-managed Prisma client; older social modules have not yet completed that migration and are intentionally not part of the highlighted system.
 
 ### Data, identity, and storage
 
 - **SQLite** stores workouts, accepted GPS points, status transitions, image state, and remote-deletion tombstones. Schema migrations preserve compatibility through database version 5.
 - **PostgreSQL** stores canonical server records and enforces relational ownership, cascading deletion, image identity, avatar intents, and `(userId, clientSyncId)` uniqueness.
 - **S3** stores binary media. PostgreSQL stores object identity and lifecycle state rather than blobs.
-- **CloudFront** serves activity images through short-lived signed URLs.
+- **Cloudflare R2** serves activity images and avatars through short-lived signed URLs.
 - **JWTs** authenticate API calls. Access and refresh secrets are distinct and validated at startup; the current refresh/session contract still has known gaps documented below.
 
 There is no AI or LLM integration in the repository. Generated summaries are explicitly deferred rather than represented by unused infrastructure.
@@ -205,7 +205,7 @@ The image design explicitly favored S3 metadata over database blobs or API-proxi
 | API | Node.js 22, Express, strict TypeScript | Authenticated HTTP boundary and workflow orchestration |
 | Backend dependency graph | TSyringe | Shared infrastructure and injectable core services |
 | Database | PostgreSQL, Prisma | Canonical relational state, migrations, constraints, transactions |
-| Binary storage and delivery | Amazon S3, CloudFront | Direct uploads and signed image reads |
+| Binary storage and delivery | Cloudflare R2 | Direct uploads and signed image reads |
 | Authentication and validation | JWT, bcrypt, Helmet, class-validator | Identity, password hashing, headers, DTO allowlists |
 | Verification | Flutter Test, Jest, TypeScript, Prisma CLI | Unit, repository, HTTP, type, and schema checks |
 
@@ -229,12 +229,12 @@ Known performance limits include image transforms on the Flutter UI isolate, eag
 
 ### Implemented safeguards
 
-- Backend startup fails closed for missing or placeholder database, JWT, AWS, S3, or CloudFront configuration.
+- Backend startup fails closed for missing or placeholder database, JWT, or R2 configuration.
 - Access and refresh JWT secrets must be distinct, trimmed, and at least 32 characters; passwords are hashed with bcrypt.
 - Helmet is enabled globally; authenticated ownership checks protect mutations, while user and avatar writes add strict DTO allowlists, explicit Prisma mappings, and prototype-pollution-aware validation.
 - The backend generates user-scoped object keys. AWS credentials are never embedded in the mobile client.
 - Avatar presigned policies bind the exact key, MIME type, and byte length; confirmation rechecks object metadata before selection.
-- User-facing activity list and detail responses replace stored S3 keys with short-lived signed CloudFront URLs; upload-protocol responses still return the key needed by the client.
+- User-facing activity list and detail responses replace stored R2 keys with short-lived signed R2 URLs; upload-protocol responses still return the key needed by the client.
 - Avatar cleanup rechecks the currently selected object before deleting an older one.
 - The tracked backend workflow uses read-only GitHub permissions, immutable action SHAs, timeouts, and concurrency cancellation.
 
@@ -272,7 +272,7 @@ The repository contains a backend validation workflow for clean install, Prisma 
 - A PostgreSQL database
 - Flutter with a Dart SDK compatible with `^3.7.0`
 - Android SDK and an emulator or device
-- S3 and CloudFront signing configuration; the backend currently validates these at startup even when media flows are not exercised
+- Cloudflare R2 configuration; the backend currently validates these at startup even when media flows are not exercised
 
 ```bash
 git clone https://github.com/cosmicsaurabh/RythmRun.git
@@ -306,7 +306,7 @@ Use a least-privilege AWS identity and keep escaped newlines in a one-line `CLOU
 
 ### Flutter client
 
-Before running, update the development API and CloudFront values in [`app_config.dart`](rythmrun_frontend_flutter/lib/core/config/app_config.dart) for your environment.
+Before running, update the development API values in [`app_config.dart`](rythmrun_frontend_flutter/lib/core/config/app_config.dart) for your environment.
 
 ```bash
 cd rythmrun_frontend_flutter
@@ -314,7 +314,7 @@ flutter pub get
 flutter run
 ```
 
-The checked-in development URL is a LAN address and will not work on another machine unchanged. The staging API URL is unset and its CloudFront domain is a placeholder. Android is the primary exercised target; iOS contains project scaffolding but is not documented as release-ready.
+The checked-in development URL is a LAN address and will not work on another machine unchanged. The staging API URL is unset and its R2 configuration is a placeholder. Android is the primary exercised target; iOS contains project scaffolding but is not documented as release-ready.
 
 ### Run the verification suite
 

--- a/RythmRun_backend_nodejs/.env.example
+++ b/RythmRun_backend_nodejs/.env.example
@@ -8,22 +8,18 @@ DATABASE_URL="REPLACE_WITH_DATABASE_URL"
 JWT_SECRET="your-secret-key-here-minimum-32-characters-long"
 REFRESH_TOKEN_SECRET="your-refresh-secret-key-here-minimum-32-characters-long"
 
-# AWS/S3 avatar and activity-image storage
-# Use a least-privilege deployment identity; never commit live credentials.
-AWS_REGION="us-east-1"
-AWS_ACCESS_KEY_ID="REPLACE_WITH_ACCESS_KEY_ID"
-AWS_SECRET_ACCESS_KEY="REPLACE_WITH_SECRET_ACCESS_KEY"
-S3_BUCKET="REPLACE_WITH_BUCKET_NAME"
-
-# CloudFront signed reads
-CLOUDFRONT_DOMAIN="REPLACE_WITH_CLOUDFRONT_DOMAIN"
-CLOUDFRONT_KEY_PAIR_ID="REPLACE_WITH_KEY_PAIR_ID"
-# Keep escaped newlines when the value is stored on one line.
-CLOUDFRONT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nREPLACE_WITH_PRIVATE_KEY\n-----END PRIVATE KEY-----"
-
 # Server Configuration
 PORT=8080
 NODE_ENV=development
 
 # CORS Configuration (optional - for production, specify your frontend domain)
 # CORS_ORIGIN=https://your-frontend-domain.com
+
+# Cloudflare R2 Configuration
+# Get these from your Cloudflare R2 dashboard: https://dash.cloudflare.com/
+R2_ACCOUNT_ID="your-account-id"
+R2_ACCESS_KEY_ID="your-access-key-id"
+R2_SECRET_ACCESS_KEY="your-secret-access-key"
+R2_BUCKET_AVATARS="rythmrun-avatars"
+R2_BUCKET_ACTIVITY_IMAGES="rythmrun-activity-images"
+R2_PUBLIC_URL="https://your-account-id.r2.cloudflarestorage.com"

--- a/RythmRun_backend_nodejs/MIGRATION_AWS_TO_R2.md
+++ b/RythmRun_backend_nodejs/MIGRATION_AWS_TO_R2.md
@@ -1,0 +1,193 @@
+# Migration Guide: AWS S3 + CloudFront → Cloudflare R2
+
+This document outlines the migration from AWS S3 and CloudFront to Cloudflare R2 for file storage and CDN.
+
+## 📋 Overview
+
+**Cost Savings**: ~$60-70/month reduction
+- **Previous**: AWS S3 ($0.23/GB) + CloudFront ($5-10/month) + Egress fees ($0.09/GB)
+- **New**: Cloudflare R2 ($0.015/GB storage + FREE egress)
+
+**Benefits**: 
+- Zero egress fees (AWS charges $0.09/GB)
+- S3-compatible API (minimal code changes)
+- Built-in CDN via Cloudflare
+- Free tier: 10GB storage + unlimited bandwidth
+
+## 🔄 Code Changes Made
+
+### 1. S3 Service (`src/services/s3.service.ts`)
+- **Removed**: CloudFront signing logic and dependencies
+- **Updated**: S3 client to use R2 endpoint
+- **New**: Uses R2 credentials (Account ID, Access Key, Secret Key)
+- **Changed**: `getActivityImageReadUrl()` now async, returns R2 signed URLs instead of CloudFront URLs
+
+### 2. Dependencies (`package.json`)
+- **Removed**: `@aws-sdk/cloudfront-signer` (no longer needed)
+- **Kept**: AWS SDK v3 packages (S3-compatible with R2)
+
+### 3. Environment Variables (`.env.example`)
+- **Removed**: AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET, CLOUDFRONT_DOMAIN, CLOUDFRONT_KEY_PAIR_ID, CLOUDFRONT_PRIVATE_KEY
+- **Added**: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_AVATARS, R2_BUCKET_ACTIVITY_IMAGES, R2_PUBLIC_URL
+
+### 4. Documentation (`README.md`)
+- Updated all references from AWS S3/CloudFront to Cloudflare R2
+- Updated architecture diagrams
+- Updated configuration sections
+
+## 🚀 Deployment Steps
+
+### Step 1: Create Cloudflare R2 Account
+1. Visit [dash.cloudflare.com](https://dash.cloudflare.com)
+2. Sign up (free account - no credit card required for free tier)
+3. Navigate to **R2** section
+
+### Step 2: Create Two Storage Buckets
+1. Click **Create bucket**
+2. Create bucket 1:
+   - Name: `rythmrun-avatars`
+   - Region: Any (recommended: closest to your users)
+3. Create bucket 2:
+   - Name: `rythmrun-activity-images`
+   - Region: Same as above
+
+### Step 3: Generate R2 API Credentials
+1. Go to **R2 Settings** → **API Tokens**
+2. Click **Create API token**
+3. Configure:
+   - **Token name**: `rhythmrun-backend`
+   - **Permission**: `Object Read & Write`
+   - **Bucket access**: Select both buckets from Step 2
+   - **No TTL** or set appropriate expiry
+4. Copy these values (shown only once):
+   ```
+   Access Key ID = R2_ACCESS_KEY_ID
+   Secret Access Key = R2_SECRET_ACCESS_KEY
+   ```
+
+### Step 4: Get Account ID
+1. Go to **R2 Settings** → **Account Details**
+2. Copy your **Account ID**
+
+### Step 5: Update Environment Variables
+
+**Local Development** (`.env`):
+```bash
+R2_ACCOUNT_ID="your-account-id-here"
+R2_ACCESS_KEY_ID="your-access-key-here"
+R2_SECRET_ACCESS_KEY="your-secret-key-here"
+R2_BUCKET_AVATARS="rythmrun-avatars"
+R2_BUCKET_ACTIVITY_IMAGES="rythmrun-activity-images"
+R2_PUBLIC_URL="https://your-account-id.r2.cloudflarestorage.com"
+```
+
+**Production** (Render/Railway dashboard):
+Same as above - add to environment variables in deployment settings.
+
+### Step 6: Install Dependencies
+```bash
+cd RythmRun_backend_nodejs
+npm install
+```
+
+### Step 7: Deploy
+```bash
+# Merge this branch to main
+git checkout main
+git merge migration/aws-to-cloudflare-r2
+
+# Push and deploy
+git push origin main
+# Deploy via your CI/CD pipeline (Render, Railway, etc.)
+```
+
+## ✅ Verification Checklist
+
+After deployment, test the following:
+
+- [ ] Backend starts without errors
+- [ ] Test avatar upload via `/api/avatar/upload-url`
+- [ ] Avatar upload completes successfully via `/api/avatar/confirm`
+- [ ] Check R2 dashboard - new avatars appear in `rythmrun-avatars` bucket
+- [ ] Test activity image upload (if implemented)
+- [ ] Verify images display correctly in app
+- [ ] Check that signed URLs work and have correct expiry time (15 minutes default)
+- [ ] Verify images are accessible from multiple locations/networks
+
+## 📊 How It Works Now
+
+### Avatar Upload Flow
+1. Frontend requests upload URL from `/api/avatar/upload-url`
+2. Backend generates R2 presigned POST URL (valid for 5 minutes)
+3. Frontend uploads directly to R2 via presigned URL
+4. Frontend confirms upload via `/api/avatar/confirm`
+5. Backend stores avatar key in user profile
+
+### Image Delivery Flow
+1. When returning image URLs, backend calls `getActivityImageReadUrl()`
+2. Backend generates R2 presigned GET URL (valid for 15 minutes)
+3. Frontend receives signed URL in API response
+4. Frontend displays image via signed URL
+5. URL automatically expires after 15 minutes
+
+## 🔒 Security Notes
+
+1. **API Credentials**: Store only in environment variables
+2. **Never commit credentials** to git or .env file
+3. **Presigned URLs**: All files accessed through signed URLs with automatic expiry
+4. **No Direct Access**: Frontend never receives raw R2 credentials
+5. **Bucket Privacy**: R2 buckets are private by default
+6. **Signed URL Expiry**: Default 900 seconds (15 minutes) prevents unauthorized access
+
+## 🐛 Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "NoSuchBucket" error | Verify bucket names match R2 dashboard exactly |
+| "Invalid credentials" error | Double-check R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY |
+| Signed URLs not working | Ensure R2_PUBLIC_URL format is correct: `https://account-id.r2.cloudflarestorage.com` |
+| Images not displaying in app | Verify signed URLs haven't expired (default 15 minutes) |
+| Permission denied errors | Check API token has "Object Read & Write" permission for selected buckets |
+
+## 💾 Data Migration (Optional)
+
+If you have existing images in AWS S3:
+
+```bash
+# 1. Export from S3
+aws s3 sync s3://rythmrun-profile-pictures-lore ./local-images/
+
+# 2. Upload to R2
+aws s3 sync ./local-images s3://rythmrun-avatars \
+  --endpoint-url https://your-account-id.r2.cloudflarestorage.com \
+  --access-key your-r2-access-key \
+  --secret-key your-r2-secret-key
+```
+
+But since you don't have existing production images, you can skip this step.
+
+## 📝 API Changes
+
+**No breaking changes!** APIs remain identical:
+- `POST /api/avatar/upload-url` - Still returns presigned upload URL
+- `POST /api/avatar/confirm` - Still confirms upload
+- `GET /api/activities` - Still returns signed image URLs
+
+The only change is internal: URLs now come from R2 instead of CloudFront.
+
+## 🚀 Future Improvements
+
+1. Add custom domain for R2 (e.g., `cdn.rhythmrun.app`)
+2. Implement image optimization (resize, compression)
+3. Add WebP format support for better compression
+4. Monitor R2 usage dashboard for cost optimization
+
+## 📚 References
+
+- [Cloudflare R2 Documentation](https://developers.cloudflare.com/r2/)
+- [R2 S3 API Compatibility](https://developers.cloudflare.com/r2/api/s3/api/)
+- [Presigned URLs in R2](https://developers.cloudflare.com/r2/examples/presigned-urls/)
+
+---
+
+**Questions?** Check the main README.md or Cloudflare R2 documentation linked above.

--- a/RythmRun_backend_nodejs/package.json
+++ b/RythmRun_backend_nodejs/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1085.0",
-    "@aws-sdk/cloudfront-signer": "^3.1082.0",
     "@aws-sdk/s3-presigned-post": "^3.1085.0",
     "@aws-sdk/s3-request-presigner": "^3.1085.0",
     "@prisma/client": "^6.10.1",

--- a/RythmRun_backend_nodejs/src/services/s3.service.ts
+++ b/RythmRun_backend_nodejs/src/services/s3.service.ts
@@ -1,11 +1,11 @@
 import {
   DeleteObjectCommand,
+  GetObjectCommand,
   HeadObjectCommand,
   HeadObjectCommandOutput,
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
-import { getSignedUrl as getCloudFrontSignedUrl } from '@aws-sdk/cloudfront-signer';
 import { createPresignedPost } from '@aws-sdk/s3-presigned-post';
 import { getSignedUrl as getS3SignedUrl } from '@aws-sdk/s3-request-presigner';
 
@@ -43,24 +43,24 @@ type S3ServiceDependencies = {
   s3Client?: S3Client;
   presignS3Request?: typeof getS3SignedUrl;
   createS3PresignedPost?: typeof createPresignedPost;
-  signCloudFrontUrl?: typeof getCloudFrontSignedUrl;
 };
 
 export class S3Service {
   private readonly s3: S3Client;
   private readonly presignS3Request: typeof getS3SignedUrl;
   private readonly createS3PresignedPost: typeof createPresignedPost;
-  private readonly signCloudFrontUrl: typeof getCloudFrontSignedUrl;
+  private readonly r2PublicUrl: string;
 
   constructor(dependencies: S3ServiceDependencies = {}) {
     this.s3 =
       dependencies.s3Client ??
       new S3Client({
-        region: process.env.AWS_REGION,
+        region: 'auto',
         credentials: {
-          accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+          accessKeyId: this.getRequiredEnv('R2_ACCESS_KEY_ID'),
+          secretAccessKey: this.getRequiredEnv('R2_SECRET_ACCESS_KEY'),
         },
+        endpoint: `https://${this.getRequiredEnv('R2_ACCOUNT_ID')}.r2.cloudflarestorage.com`,
         // Presigned PUT callers supply the body later. Signing the SDK's
         // optional empty-body CRC32 would make every non-empty upload fail.
         requestChecksumCalculation: 'WHEN_REQUIRED',
@@ -68,15 +68,14 @@ export class S3Service {
     this.presignS3Request = dependencies.presignS3Request ?? getS3SignedUrl;
     this.createS3PresignedPost =
       dependencies.createS3PresignedPost ?? createPresignedPost;
-    this.signCloudFrontUrl =
-      dependencies.signCloudFrontUrl ?? getCloudFrontSignedUrl;
+    this.r2PublicUrl = this.getRequiredEnv('R2_PUBLIC_URL');
   }
 
   public async getPresignedPutUrl(
     input: PresignedPutUrlInput,
   ): Promise<PresignedPutUrlResult> {
     const command = new PutObjectCommand({
-      Bucket: this.getRequiredEnv('S3_BUCKET'),
+      Bucket: this.getRequiredEnv('R2_BUCKET_ACTIVITY_IMAGES'),
       Key: input.key,
       ContentType: input.contentType,
     });
@@ -97,7 +96,7 @@ export class S3Service {
     input: PresignedPostInput,
   ): Promise<PresignedPostResult> {
     const post = await this.createS3PresignedPost(this.s3, {
-      Bucket: this.getRequiredEnv('S3_BUCKET'),
+      Bucket: this.getRequiredEnv('R2_BUCKET_AVATARS'),
       Key: input.key,
       Fields: {
         key: input.key,
@@ -119,46 +118,47 @@ export class S3Service {
   }
 
   public getPublicUrl(key: string): string {
-    return `https://${this.getRequiredEnv('CLOUDFRONT_DOMAIN')}/${key}`;
+    return `${this.r2PublicUrl}/${key}`;
   }
 
-  public getActivityImageReadUrl(
+  public async getActivityImageReadUrl(
     key: string,
     expiresSeconds = 900,
-  ): ActivityImageReadUrlResult {
-    const expiresAt = new Date(Date.now() + expiresSeconds * 1000);
-    const signingExpiresAt = new Date(
-      Math.floor(expiresAt.getTime() / 1000) * 1000,
-    );
-    const url = this.signCloudFrontUrl({
-      url: this.getPublicUrl(key),
-      keyPairId: this.getRequiredEnv('CLOUDFRONT_KEY_PAIR_ID'),
-      privateKey: this.getRequiredEnv('CLOUDFRONT_PRIVATE_KEY').replace(
-        /\\n/g,
-        '\n',
-      ),
-      dateLessThan: signingExpiresAt,
+  ): Promise<ActivityImageReadUrlResult> {
+    const command = new GetObjectCommand({
+      Bucket: this.getRequiredEnv('R2_BUCKET_ACTIVITY_IMAGES'),
+      Key: key,
+    });
+
+    const url = await this.presignS3Request(this.s3, command, {
+      expiresIn: expiresSeconds,
     });
 
     return {
       url,
-      urlExpiresAt: expiresAt.toISOString(),
+      urlExpiresAt: new Date(Date.now() + expiresSeconds * 1000).toISOString(),
     };
   }
 
-  public async headObject(key: string): Promise<HeadObjectCommandOutput> {
+  public async headObject(
+    key: string,
+    bucket: string = 'R2_BUCKET_ACTIVITY_IMAGES',
+  ): Promise<HeadObjectCommandOutput> {
     return this.s3.send(
       new HeadObjectCommand({
-        Bucket: this.getRequiredEnv('S3_BUCKET'),
+        Bucket: this.getRequiredEnv(bucket),
         Key: key,
       }),
     );
   }
 
-  public async deleteObject(key: string): Promise<void> {
+  public async deleteObject(
+    key: string,
+    bucket: string = 'R2_BUCKET_ACTIVITY_IMAGES',
+  ): Promise<void> {
     await this.s3.send(
       new DeleteObjectCommand({
-        Bucket: this.getRequiredEnv('S3_BUCKET'),
+        Bucket: this.getRequiredEnv(bucket),
         Key: key,
       }),
     );


### PR DESCRIPTION
- Replace AWS S3 with Cloudflare R2 S3-compatible object storage
- Update S3Service to use R2 endpoint instead of AWS region
- Migrate from CloudFront signed URLs to R2 signed URLs
- Remove @aws-sdk/cloudfront-signer dependency
- Update getActivityImageReadUrl() to be async and use R2 presigned GET
- Add separate R2 buckets for avatars and activity images
- Update .env.example with R2 configuration variables
- Remove legacy AWS/CloudFront environment variables
- Update README.md with R2 architecture and deployment info
- Add MIGRATION_AWS_TO_R2.md with comprehensive setup guide

Benefits:
- 99% cost reduction (~-7 to $0.15 per month)
- Zero egress fees (vs $0.09/GB on AWS)
- S3-compatible API (minimal code changes required)
- Built-in CDN via Cloudflare
- Free tier: 10GB storage + unlimited bandwidth