### PR TITLE
feat(auth): add email sender abstraction and optional SMTP config

### DIFF
--- a/RythmRun_backend_nodejs/package-lock.json
+++ b/RythmRun_backend_nodejs/package-lock.json
@@ -23,6 +23,7 @@
         "google-auth-library": "^10.9.0",
         "helmet": "^8.3.0",
         "jsonwebtoken": "^9.0.3",
+        "nodemailer": "^9.0.3",
         "pg": "8.22.0",
         "reflect-metadata": "^0.2.2",
         "tsyringe": "^4.10.0"
@@ -34,6 +35,7 @@
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "22.20.1",
+        "@types/nodemailer": "^8.0.1",
         "@types/pg": "8.20.0",
         "jest": "^30.4.2",
         "nodemon": "^3.1.14",
@@ -2368,6 +2370,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -6186,6 +6198,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/RythmRun_backend_nodejs/package.json
+++ b/RythmRun_backend_nodejs/package.json
@@ -38,6 +38,7 @@
     "google-auth-library": "^10.9.0",
     "helmet": "^8.3.0",
     "jsonwebtoken": "^9.0.3",
+    "nodemailer": "^9.0.3",
     "pg": "8.22.0",
     "reflect-metadata": "^0.2.2",
     "tsyringe": "^4.10.0"
@@ -49,6 +50,7 @@
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "22.20.1",
+    "@types/nodemailer": "^8.0.1",
     "@types/pg": "8.20.0",
     "jest": "^30.4.2",
     "nodemon": "^3.1.14",

--- a/RythmRun_backend_nodejs/src/__tests__/dependency-surface.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/dependency-surface.test.ts
@@ -50,6 +50,11 @@ describe('backend production dependency surface', () => {
     expect(dependencies['google-auth-library']).toEqual(expect.any(String));
   });
 
+  it('declares nodemailer as an explicit production dependency for email', () => {
+    expect(dependencies.nodemailer).toEqual(expect.any(String));
+    expect(devDependencies['@types/nodemailer']).toEqual(expect.any(String));
+  });
+
   it('keeps the end-of-support monolithic AWS SDK out of the dependency graph', () => {
     expect(allDeclaredDependencies).not.toHaveProperty('aws-sdk');
     expect(

--- a/RythmRun_backend_nodejs/src/__tests__/email.service.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/email.service.test.ts
@@ -1,0 +1,110 @@
+import { jest } from '@jest/globals';
+import type { Transporter } from 'nodemailer';
+
+import type { EmailEnvironment } from '../config/env.js';
+import {
+  NoopEmailSender,
+  NodemailerEmailSender,
+  buildVerificationUrl,
+  createEmailSender,
+} from '../services/email.service.js';
+
+const config: EmailEnvironment = {
+  host: 'smtp-relay.brevo.com',
+  port: 587,
+  secure: false,
+  user: 'mailer@reshapeapp.ai',
+  pass: 'brevo-smtp-key',
+  from: 'RythmRun <noreply@reshapeapp.ai>',
+  publicAppUrl: 'https://rythmrun.onrender.com',
+};
+
+function fakeTransport(): {
+  transporter: Transporter;
+  sendMail: jest.Mock;
+} {
+  const sendMail = jest.fn<() => Promise<unknown>>().mockResolvedValue({});
+  return {
+    transporter: { sendMail } as unknown as Transporter,
+    sendMail,
+  };
+}
+
+describe('buildVerificationUrl', () => {
+  it('joins the base URL, route, and url-encoded token', () => {
+    expect(buildVerificationUrl('https://rythmrun.onrender.com', 'a b/c')).toBe(
+      'https://rythmrun.onrender.com/api/users/verify-email?token=a%20b%2Fc',
+    );
+  });
+});
+
+describe('createEmailSender', () => {
+  it('returns a disabled no-op sender when config is null', async () => {
+    const sender = createEmailSender(null);
+    expect(sender).toBeInstanceOf(NoopEmailSender);
+    expect(sender.enabled).toBe(false);
+    await expect(
+      sender.sendEmailVerification({ to: 'x@y.com', rawToken: 'tok' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('returns an enabled SMTP sender when config is present', () => {
+    const { transporter } = fakeTransport();
+    const sender = createEmailSender(config, transporter);
+    expect(sender).toBeInstanceOf(NodemailerEmailSender);
+    expect(sender.enabled).toBe(true);
+  });
+});
+
+describe('NodemailerEmailSender', () => {
+  it('sends a verification email with both text and html parts', async () => {
+    const { transporter, sendMail } = fakeTransport();
+    const sender = new NodemailerEmailSender(config, transporter);
+
+    await sender.sendEmailVerification({
+      to: 'runner@example.com',
+      firstname: 'Ada',
+      rawToken: 'secret-token',
+    });
+
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    const message = sendMail.mock.calls[0][0] as {
+      from: string;
+      to: string;
+      subject: string;
+      text: string;
+      html: string;
+    };
+    expect(message.from).toBe(config.from);
+    expect(message.to).toBe('runner@example.com');
+    const expectedUrl = buildVerificationUrl(config.publicAppUrl, 'secret-token');
+    expect(message.text).toContain(expectedUrl);
+    expect(message.html).toContain(expectedUrl);
+    expect(message.html).toContain('Ada');
+  });
+
+  it('propagates transport failures to the caller', async () => {
+    const { transporter, sendMail } = fakeTransport();
+    sendMail.mockRejectedValueOnce(new Error('SMTP 535 auth failed'));
+    const sender = new NodemailerEmailSender(config, transporter);
+
+    await expect(
+      sender.sendEmailVerification({ to: 'x@y.com', rawToken: 'tok' }),
+    ).rejects.toThrow('SMTP 535 auth failed');
+  });
+
+  it('escapes a user-controlled firstname in the HTML body', async () => {
+    const { transporter, sendMail } = fakeTransport();
+    const sender = new NodemailerEmailSender(config, transporter);
+
+    await sender.sendEmailVerification({
+      to: 'x@y.com',
+      firstname: '<script>alert(1)</script>',
+      rawToken: 'tok',
+    });
+
+    const message = sendMail.mock.calls[0][0] as { html: string };
+    expect(message.html).not.toContain('<script>alert(1)</script>');
+    expect(message.html).toContain('&lt;script&gt;');
+  });
+});

--- a/RythmRun_backend_nodejs/src/__tests__/env.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/env.test.ts
@@ -2,6 +2,7 @@ import {
   EnvironmentValidationError,
   MINIMUM_JWT_SECRET_LENGTH,
   getJwtSecrets,
+  validateEmailEnvironment,
   validateJwtSecrets,
   validateServerEnvironment,
 } from '../config/env.js';
@@ -160,5 +161,91 @@ describe('server environment validation', () => {
         GOOGLE_SERVER_CLIENT_ID: clientId,
       }),
     ).toThrow('GOOGLE_SERVER_CLIENT_ID');
+  });
+});
+
+describe('email environment validation', () => {
+  const validEmailEnvironment = {
+    SMTP_HOST: 'smtp-relay.brevo.com',
+    SMTP_PORT: '587',
+    SMTP_SECURE: 'false',
+    SMTP_USER: 'mailer@reshapeapp.ai',
+    SMTP_PASS: 'brevo-smtp-key',
+    MAIL_FROM: 'RythmRun <noreply@reshapeapp.ai>',
+    PUBLIC_APP_URL: 'https://rythmrun.onrender.com',
+  };
+
+  it('returns null when no email variables are set (feature disabled)', () => {
+    expect(validateEmailEnvironment({})).toBeNull();
+  });
+
+  it('parses a fully configured mailer with defaults applied', () => {
+    expect(validateEmailEnvironment(validEmailEnvironment)).toEqual({
+      host: 'smtp-relay.brevo.com',
+      port: 587,
+      secure: false,
+      user: 'mailer@reshapeapp.ai',
+      pass: 'brevo-smtp-key',
+      from: 'RythmRun <noreply@reshapeapp.ai>',
+      publicAppUrl: 'https://rythmrun.onrender.com',
+    });
+  });
+
+  it('defaults port to 587 and secure to false when omitted', () => {
+    const source: Record<string, string | undefined> = {
+      ...validEmailEnvironment,
+    };
+    delete source.SMTP_PORT;
+    delete source.SMTP_SECURE;
+
+    const result = validateEmailEnvironment(source);
+    expect(result?.port).toBe(587);
+    expect(result?.secure).toBe(false);
+  });
+
+  it('strips a trailing slash from PUBLIC_APP_URL for clean link building', () => {
+    expect(
+      validateEmailEnvironment({
+        ...validEmailEnvironment,
+        PUBLIC_APP_URL: 'https://rythmrun.onrender.com/',
+      })?.publicAppUrl,
+    ).toBe('https://rythmrun.onrender.com');
+  });
+
+  it.each(['SMTP_HOST', 'SMTP_USER', 'SMTP_PASS', 'MAIL_FROM', 'PUBLIC_APP_URL'])(
+    'throws when partially configured and %s is missing',
+    (name) => {
+      const source: Record<string, string | undefined> = {
+        ...validEmailEnvironment,
+      };
+      delete source[name];
+
+      expect(() => validateEmailEnvironment(source)).toThrow(
+        EnvironmentValidationError,
+      );
+    },
+  );
+
+  it.each([
+    'not-a-url',
+    'ftp://rythmrun.onrender.com',
+    ' https://rythmrun.onrender.com',
+    'REPLACE_WITH_PUBLIC_APP_URL',
+  ])('rejects an invalid PUBLIC_APP_URL: %s', (url) => {
+    expect(() =>
+      validateEmailEnvironment({ ...validEmailEnvironment, PUBLIC_APP_URL: url }),
+    ).toThrow('PUBLIC_APP_URL');
+  });
+
+  it.each(['0', '70000', 'abc'])('rejects an invalid SMTP_PORT: %s', (port) => {
+    expect(() =>
+      validateEmailEnvironment({ ...validEmailEnvironment, SMTP_PORT: port }),
+    ).toThrow('SMTP_PORT');
+  });
+
+  it('rejects a non-boolean SMTP_SECURE', () => {
+    expect(() =>
+      validateEmailEnvironment({ ...validEmailEnvironment, SMTP_SECURE: 'yes' }),
+    ).toThrow('SMTP_SECURE');
   });
 });

--- a/RythmRun_backend_nodejs/src/__tests__/server-bootstrap.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/server-bootstrap.test.ts
@@ -56,6 +56,7 @@ jest.unstable_mockModule('../config/env.js', () => ({
       GOOGLE_SERVER_CLIENT_ID: 'test.apps.googleusercontent.com',
     };
   }),
+  validateEmailEnvironment: jest.fn(() => null),
 }));
 
 jest.unstable_mockModule('../app.js', () => {

--- a/RythmRun_backend_nodejs/src/config/container.ts
+++ b/RythmRun_backend_nodejs/src/config/container.ts
@@ -11,6 +11,8 @@ import { FriendService } from '../services/friend.service.js';
 import { AvatarService } from '../services/avatar.service.js';
 import { AuthSessionService } from '../services/auth-session.service.js';
 import { GoogleAuthService } from '../services/google-auth.service.js';
+import { createEmailSender } from '../services/email.service.js';
+import type { EmailEnvironment } from './env.js';
 import s3Service from '../services/s3.service.js';
 
 export const container = rootContainer.createChildContainer();
@@ -19,6 +21,7 @@ let configured = false;
 export function configureContainer(
   databaseUrl: string,
   googleServerClientId: string,
+  emailConfig: EmailEnvironment | null = null,
 ): DatabaseRuntime {
   if (configured) {
     throw new Error('Dependency container is already configured');
@@ -31,6 +34,9 @@ export function configureContainer(
     'GoogleIdentityVerifier',
     new GoogleAuthService(googleServerClientId),
   );
+  // Always registered so the DI token resolves even when email is disabled;
+  // createEmailSender returns a no-op sender for a null config.
+  container.registerInstance('EmailSender', createEmailSender(emailConfig));
 
   container.register('AuthSessionService', { useClass: AuthSessionService });
   container.register('UserService', { useClass: UserService });

--- a/RythmRun_backend_nodejs/src/config/env.ts
+++ b/RythmRun_backend_nodejs/src/config/env.ts
@@ -20,6 +20,35 @@ export interface ServerEnvironment {
   R2_PUBLIC_URL: string;
 }
 
+/**
+ * Optional email/SMTP configuration. Email verification is a feature module:
+ * when NONE of these variables are set the feature is disabled and the app
+ * still boots (fail-closed only for the always-required ServerEnvironment).
+ * When ANY are set, ALL required fields must be present — a half-configured
+ * mailer is worse than none.
+ */
+export interface EmailEnvironment {
+  host: string;
+  port: number;
+  secure: boolean;
+  user: string;
+  pass: string;
+  from: string;
+  publicAppUrl: string;
+}
+
+export const EMAIL_ENVIRONMENT_VARIABLES = [
+  'SMTP_HOST',
+  'SMTP_PORT',
+  'SMTP_SECURE',
+  'SMTP_USER',
+  'SMTP_PASS',
+  'MAIL_FROM',
+  'PUBLIC_APP_URL',
+] as const;
+
+export const DEFAULT_SMTP_PORT = 587;
+
 export const MINIMUM_JWT_SECRET_LENGTH = 32;
 
 export const REQUIRED_SERVER_ENVIRONMENT_VARIABLES = [
@@ -189,6 +218,96 @@ export function validateServerEnvironment(
     R2_PUBLIC_URL: requireConfiguredEnvironmentVariable(
       source,
       'R2_PUBLIC_URL',
+    ),
+  };
+}
+
+function parsePublicAppUrl(value: string): string {
+  if (value !== value.trim()) {
+    throw new EnvironmentValidationError(
+      'PUBLIC_APP_URL must not have leading or trailing whitespace',
+    );
+  }
+  if (DOCUMENTED_CONFIGURATION_PLACEHOLDER.test(value)) {
+    throw new EnvironmentValidationError(
+      'PUBLIC_APP_URL must not use a documented placeholder',
+    );
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new EnvironmentValidationError(
+      'PUBLIC_APP_URL must be an absolute http(s) URL',
+    );
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new EnvironmentValidationError(
+      'PUBLIC_APP_URL must use the http or https scheme',
+    );
+  }
+
+  // Normalize away trailing slashes so verification links concatenate cleanly.
+  return value.replace(/\/+$/, '');
+}
+
+function parseSmtpPort(source: EnvironmentSource): number {
+  const raw = source.SMTP_PORT;
+  if (raw === undefined || raw.trim().length === 0) {
+    return DEFAULT_SMTP_PORT;
+  }
+
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new EnvironmentValidationError(
+      'SMTP_PORT must be an integer between 1 and 65535',
+    );
+  }
+  return port;
+}
+
+function parseSmtpSecure(source: EnvironmentSource): boolean {
+  const raw = source.SMTP_SECURE;
+  if (raw === undefined || raw.trim().length === 0) {
+    return false;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === 'true') {
+    return true;
+  }
+  if (normalized === 'false') {
+    return false;
+  }
+  throw new EnvironmentValidationError("SMTP_SECURE must be 'true' or 'false'");
+}
+
+/**
+ * Validates the optional email feature configuration. Returns null when the
+ * feature is entirely unconfigured (no email variables set), and throws when
+ * it is only partially configured so a broken mailer never boots silently.
+ */
+export function validateEmailEnvironment(
+  source: EnvironmentSource,
+): EmailEnvironment | null {
+  const anyConfigured = EMAIL_ENVIRONMENT_VARIABLES.some((name) => {
+    const value = source[name];
+    return value !== undefined && value.trim().length > 0;
+  });
+  if (!anyConfigured) {
+    return null;
+  }
+
+  return {
+    host: requireEnvironmentVariable(source, 'SMTP_HOST'),
+    port: parseSmtpPort(source),
+    secure: parseSmtpSecure(source),
+    user: requireEnvironmentVariable(source, 'SMTP_USER'),
+    pass: requireEnvironmentVariable(source, 'SMTP_PASS'),
+    from: requireEnvironmentVariable(source, 'MAIL_FROM'),
+    publicAppUrl: parsePublicAppUrl(
+      requireEnvironmentVariable(source, 'PUBLIC_APP_URL'),
     ),
   };
 }

--- a/RythmRun_backend_nodejs/src/server.ts
+++ b/RythmRun_backend_nodejs/src/server.ts
@@ -2,7 +2,10 @@ import 'reflect-metadata';
 import type { Server } from 'node:http';
 import os from 'node:os';
 
-import { loadAndValidateEnvironment } from './config/env.js';
+import {
+  loadAndValidateEnvironment,
+  validateEmailEnvironment,
+} from './config/env.js';
 import type { DatabaseRuntime } from './config/database.js';
 import type { ActivityImageService } from './services/activity-image.service.js';
 import type { AvatarService } from './services/avatar.service.js';
@@ -107,6 +110,8 @@ export async function startServer(
   options: StartServerOptions = {},
 ): Promise<Server> {
   const environment = loadAndValidateEnvironment();
+  // Optional feature config; null disables email delivery without blocking boot.
+  const emailConfig = validateEmailEnvironment(process.env);
   const port = getPort(options.port);
   let database: DatabaseRuntime | undefined;
 
@@ -117,6 +122,7 @@ export async function startServer(
     database = configureContainer(
       environment.DATABASE_URL,
       environment.GOOGLE_SERVER_CLIENT_ID,
+      emailConfig,
     );
 
     const [

--- a/RythmRun_backend_nodejs/src/services/email.service.ts
+++ b/RythmRun_backend_nodejs/src/services/email.service.ts
@@ -1,0 +1,104 @@
+import nodemailer, { type Transporter } from 'nodemailer';
+
+import type { EmailEnvironment } from '../config/env.js';
+import {
+  VERIFICATION_EMAIL_SUBJECT,
+  renderVerificationEmailHtml,
+  renderVerificationEmailText,
+} from '../templates/email-verification.template.js';
+
+export interface SendEmailVerificationInput {
+  to: string;
+  firstname?: string | null;
+  rawToken: string;
+}
+
+/**
+ * Transport-agnostic email boundary. UserService depends only on this
+ * interface, so delivery can be swapped (SMTP provider, HTTP API, no-op)
+ * without touching auth logic, and unit tests inject a fake.
+ */
+export interface EmailSender {
+  readonly enabled: boolean;
+  sendEmailVerification(input: SendEmailVerificationInput): Promise<void>;
+}
+
+// The path of the public, unauthenticated verification GET route. Kept here
+// because building the emailed link is an email concern.
+const VERIFY_EMAIL_PATH = '/api/users/verify-email';
+
+export function buildVerificationUrl(
+  publicAppUrl: string,
+  rawToken: string,
+): string {
+  return `${publicAppUrl}${VERIFY_EMAIL_PATH}?token=${encodeURIComponent(rawToken)}`;
+}
+
+/**
+ * Used when email is not configured. Verification links are simply not sent;
+ * the rest of the app (registration, login, banner) still works.
+ */
+export class NoopEmailSender implements EmailSender {
+  readonly enabled = false;
+
+  async sendEmailVerification(): Promise<void> {
+    // Intentionally does nothing; email delivery is disabled.
+  }
+}
+
+export class NodemailerEmailSender implements EmailSender {
+  readonly enabled = true;
+  private readonly transporter: Transporter;
+
+  constructor(
+    private readonly config: EmailEnvironment,
+    transporter?: Transporter,
+  ) {
+    this.transporter =
+      transporter ??
+      nodemailer.createTransport({
+        host: config.host,
+        port: config.port,
+        secure: config.secure,
+        // Force STARTTLS on non-implicit-TLS ports (e.g. 587) so credentials
+        // and links are never transmitted in cleartext.
+        requireTLS: !config.secure,
+        auth: { user: config.user, pass: config.pass },
+      });
+  }
+
+  async sendEmailVerification(input: SendEmailVerificationInput): Promise<void> {
+    const verificationUrl = buildVerificationUrl(
+      this.config.publicAppUrl,
+      input.rawToken,
+    );
+    await this.transporter.sendMail({
+      from: this.config.from,
+      to: input.to,
+      subject: VERIFICATION_EMAIL_SUBJECT,
+      text: renderVerificationEmailText({
+        firstname: input.firstname,
+        verificationUrl,
+      }),
+      html: renderVerificationEmailHtml({
+        firstname: input.firstname,
+        verificationUrl,
+      }),
+    });
+  }
+}
+
+/**
+ * Resolves the concrete sender from optional config: a real SMTP sender when
+ * configured, otherwise a no-op. Always returns an EmailSender so the DI token
+ * can be registered unconditionally.
+ */
+export function createEmailSender(
+  config: EmailEnvironment | null,
+  transporter?: Transporter,
+): EmailSender {
+  if (config === null) {
+    return new NoopEmailSender();
+  }
+  return new NodemailerEmailSender(config, transporter);
+}

--- a/RythmRun_backend_nodejs/src/templates/email-verification.template.ts
+++ b/RythmRun_backend_nodejs/src/templates/email-verification.template.ts
@@ -1,0 +1,90 @@
+export interface VerificationEmailContent {
+  firstname?: string | null;
+  verificationUrl: string;
+}
+
+export const VERIFICATION_EMAIL_SUBJECT = 'Verify your RythmRun email';
+
+const BRAND = 'RythmRun';
+const ACCENT = '#0e9c74';
+
+/**
+ * firstname is user-supplied and verificationUrl is embedded in HTML, so both
+ * are escaped before interpolation to prevent HTML/attribute injection in the
+ * rendered email.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function greetingName(firstname?: string | null): string {
+  const trimmed = firstname?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : 'there';
+}
+
+export function renderVerificationEmailText(
+  content: VerificationEmailContent,
+): string {
+  const name = greetingName(content.firstname);
+  return [
+    `Hi ${name},`,
+    '',
+    `Confirm your email address to finish setting up your ${BRAND} account.`,
+    '',
+    'Open this link to verify:',
+    content.verificationUrl,
+    '',
+    'This link expires in 24 hours. If you did not create a RythmRun account,',
+    'you can safely ignore this email.',
+  ].join('\n');
+}
+
+export function renderVerificationEmailHtml(
+  content: VerificationEmailContent,
+): string {
+  const name = escapeHtml(greetingName(content.firstname));
+  const url = escapeHtml(content.verificationUrl);
+  return `<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:0;background:#f5f6f8;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#14181d;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f5f6f8;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px;background:#ffffff;border-radius:12px;padding:32px;">
+            <tr>
+              <td style="font-size:20px;font-weight:700;letter-spacing:-0.01em;padding-bottom:8px;">${BRAND}</td>
+            </tr>
+            <tr>
+              <td style="font-size:16px;line-height:1.6;color:#3d454e;padding-bottom:20px;">
+                Hi ${name},<br /><br />
+                Confirm your email address to finish setting up your ${BRAND} account.
+              </td>
+            </tr>
+            <tr>
+              <td style="padding-bottom:24px;">
+                <a href="${url}" style="display:inline-block;background:${ACCENT};color:#ffffff;text-decoration:none;font-weight:600;font-size:15px;padding:12px 24px;border-radius:8px;">Verify email</a>
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:13px;line-height:1.6;color:#667079;">
+                Or paste this link into your browser:<br />
+                <a href="${url}" style="color:${ACCENT};word-break:break-all;">${url}</a>
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:12px;line-height:1.6;color:#98a0a8;padding-top:24px;border-top:1px solid #e8ecf1;">
+                This link expires in 24 hours. If you did not create a ${BRAND} account, you can safely ignore this email.
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}


### PR DESCRIPTION
Adds the email-delivery layer behind a swappable interface, wired as an optional feature so the server still boots without mail configured.

- validateEmailEnvironment(): a separate, optional env validator that does NOT widen the fail-closed ServerEnvironment. Returns null when no email vars are set; throws only when partially configured. Adds PUBLIC_APP_URL (validated absolute http(s), trailing slash normalized) for building the verification link. SMTP_PORT defaults to 587, SMTP_SECURE to false.
- EmailSender interface with NodemailerEmailSender (SMTP; STARTTLS forced on non-implicit-TLS ports) and NoopEmailSender. createEmailSender() resolves a no-op when unconfigured. Transport is injectable for unit tests.
- Verification email template (text + HTML parts); the user-controlled firstname is HTML-escaped to prevent injection.
- Register the EmailSender DI token unconditionally; server.ts validates and passes the optional email config into configureContainer.
- nodemailer added as a prod dependency (+ @types/nodemailer dev), asserted in dependency-surface.test.

Not yet consumed by any route; that lands in the next chunk.