### PR TITLE
feat(auth): send, verify, and resend email verification links

### DIFF
--- a/RythmRun_backend_nodejs/src/__tests__/http-security-boundary.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/http-security-boundary.test.ts
@@ -5,6 +5,8 @@ const mockProductionController = {
   register: jest.fn(),
   login: jest.fn(),
   googleAuth: jest.fn(),
+  verifyEmail: jest.fn(),
+  resendVerification: jest.fn(),
   logout: jest.fn(),
   refreshToken: jest.fn(),
   me: jest.fn(),

--- a/RythmRun_backend_nodejs/src/__tests__/server-bootstrap.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/server-bootstrap.test.ts
@@ -6,6 +6,7 @@ const mockEvents: string[] = [];
 const mockRetryPendingDeletes = jest.fn().mockResolvedValue(undefined);
 const mockRetryPendingCleanup = jest.fn().mockResolvedValue(undefined);
 const mockPurgeExpiredSessions = jest.fn().mockResolvedValue(0);
+const mockPurgeExpiredVerificationTokens = jest.fn().mockResolvedValue(0);
 const mockResolve = jest.fn((token: string) => {
   if (token === 'ActivityImageService') {
     return { retryPendingDeletes: mockRetryPendingDeletes };
@@ -17,6 +18,12 @@ const mockResolve = jest.fn((token: string) => {
 
   if (token === 'AuthSessionService') {
     return { purgeExpiredSessions: mockPurgeExpiredSessions };
+  }
+
+  if (token === 'UserService') {
+    return {
+      purgeExpiredVerificationTokens: mockPurgeExpiredVerificationTokens,
+    };
   }
 
   throw new Error(`Unexpected service token: ${token}`);
@@ -149,9 +156,11 @@ describe('server bootstrap', () => {
     expect(mockResolve).toHaveBeenCalledWith('ActivityImageService');
     expect(mockResolve).toHaveBeenCalledWith('AvatarService');
     expect(mockResolve).toHaveBeenCalledWith('AuthSessionService');
+    expect(mockResolve).toHaveBeenCalledWith('UserService');
     expect(mockRetryPendingDeletes).toHaveBeenCalledTimes(1);
     expect(mockRetryPendingCleanup).toHaveBeenCalledTimes(1);
     expect(mockPurgeExpiredSessions).toHaveBeenCalledTimes(1);
+    expect(mockPurgeExpiredVerificationTokens).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(
       'Avatar cleanup retry failed (AvatarCleanupError)',
     );

--- a/RythmRun_backend_nodejs/src/__tests__/user-auth.service.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/user-auth.service.test.ts
@@ -64,6 +64,12 @@ function harness() {
       create: jest.fn().mockResolvedValue(user),
       findUnique: jest.fn().mockResolvedValue(user),
       findFirst: jest.fn().mockResolvedValue(null),
+      update: jest.fn().mockResolvedValue(user),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    verificationToken: {
+      upsert: jest.fn().mockResolvedValue({}),
+      findUnique: jest.fn().mockResolvedValue(null),
       updateMany: jest.fn().mockResolvedValue({ count: 1 }),
     },
   };
@@ -71,6 +77,10 @@ function harness() {
     user: {
       findUnique: jest.fn(),
       updateMany: jest.fn(),
+    },
+    verificationToken: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
     },
   };
   const authSessions = {
@@ -87,15 +97,21 @@ function harness() {
   const googleIdentityVerifier = {
     verifyIdToken: jest.fn().mockResolvedValue(googleIdentity),
   };
+  const emailSender = {
+    enabled: true,
+    sendEmailVerification: jest.fn().mockResolvedValue(undefined),
+  };
   return {
     transaction,
     prisma,
     authSessions,
     googleIdentityVerifier,
+    emailSender,
     service: new UserService(
       prisma as never,
       authSessions as never,
       googleIdentityVerifier,
+      emailSender as never,
     ),
   };
 }
@@ -106,7 +122,7 @@ describe('UserService authentication lifecycle', () => {
   });
 
   it('creates the user and its first session in one transaction', async () => {
-    const { service, transaction, authSessions } = harness();
+    const { service, transaction, authSessions, emailSender } = harness();
     jest.mocked(bcrypt.hash).mockResolvedValue('new-hash' as never);
 
     const result = await service.register({
@@ -129,6 +145,130 @@ describe('UserService authentication lifecycle', () => {
       transaction,
       user,
     );
+    // A verification token is issued in-transaction and the email is sent
+    // afterwards (post-commit, best-effort).
+    expect(transaction.verificationToken.upsert).toHaveBeenCalledTimes(1);
+    expect(emailSender.sendEmailVerification).toHaveBeenCalledTimes(1);
+  });
+
+  it('still registers when the post-commit verification email fails', async () => {
+    const { service, emailSender } = harness();
+    jest.mocked(bcrypt.hash).mockResolvedValue('new-hash' as never);
+    emailSender.sendEmailVerification.mockRejectedValueOnce(
+      new Error('SMTP down'),
+    );
+
+    await expect(
+      service.register({
+        username: 'runner@example.com',
+        password: 'correct-horse-battery-staple',
+      }),
+    ).resolves.toEqual(authResponse);
+  });
+
+  it('verifies an email with a valid unconsumed token', async () => {
+    const { service, transaction } = harness();
+    transaction.verificationToken.findUnique.mockResolvedValueOnce({
+      userId: user.id,
+      tokenDigest: 'digest',
+      consumedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    transaction.verificationToken.updateMany.mockResolvedValueOnce({
+      count: 1,
+    });
+
+    await expect(service.verifyEmail('raw-token')).resolves.toBe('verified');
+    expect(transaction.user.update).toHaveBeenCalledWith({
+      where: { id: user.id },
+      data: { emailVerified: true },
+    });
+  });
+
+  it('is idempotent for a consumed token on an already-verified user', async () => {
+    const { service, transaction } = harness();
+    transaction.verificationToken.findUnique.mockResolvedValueOnce({
+      userId: user.id,
+      consumedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    transaction.user.findUnique.mockResolvedValueOnce({ emailVerified: true });
+
+    await expect(service.verifyEmail('raw-token')).resolves.toBe(
+      'already_verified',
+    );
+    expect(transaction.user.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown verification token', async () => {
+    const { service, transaction } = harness();
+    transaction.verificationToken.findUnique.mockResolvedValueOnce(null);
+
+    await expect(service.verifyEmail('raw-token')).rejects.toMatchObject({
+      code: 'AUTH_VERIFICATION_TOKEN_INVALID',
+    });
+  });
+
+  it('rejects an empty token without touching the database', async () => {
+    const { service, authSessions } = harness();
+
+    await expect(service.verifyEmail('')).rejects.toMatchObject({
+      code: 'AUTH_VERIFICATION_TOKEN_INVALID',
+    });
+    expect(authSessions.withSerializableTransaction).not.toHaveBeenCalled();
+  });
+
+  it('resends verification and rotates the token for an unverified user', async () => {
+    const { service, prisma, transaction, emailSender } = harness();
+    prisma.user.findUnique.mockResolvedValueOnce({
+      ...user,
+      emailVerified: false,
+    });
+    prisma.verificationToken.findUnique.mockResolvedValueOnce({
+      lastSentAt: null,
+    });
+
+    await service.resendVerification(user.id);
+
+    expect(transaction.verificationToken.upsert).toHaveBeenCalledTimes(1);
+    expect(emailSender.sendEmailVerification).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not resend for an already-verified account', async () => {
+    const { service, prisma, authSessions, emailSender } = harness();
+    prisma.user.findUnique.mockResolvedValueOnce({
+      ...user,
+      emailVerified: true,
+    });
+
+    await service.resendVerification(user.id);
+
+    expect(authSessions.withSerializableTransaction).not.toHaveBeenCalled();
+    expect(emailSender.sendEmailVerification).not.toHaveBeenCalled();
+  });
+
+  it('throttles a resend inside the cooldown window', async () => {
+    const { service, prisma, emailSender } = harness();
+    prisma.user.findUnique.mockResolvedValueOnce({
+      ...user,
+      emailVerified: false,
+    });
+    prisma.verificationToken.findUnique.mockResolvedValueOnce({
+      lastSentAt: new Date(),
+    });
+
+    await expect(service.resendVerification(user.id)).rejects.toMatchObject({
+      code: 'AUTH_VERIFICATION_RATE_LIMITED',
+      statusCode: 429,
+    });
+    expect(emailSender.sendEmailVerification).not.toHaveBeenCalled();
+  });
+
+  it('purges expired verification tokens', async () => {
+    const { service, prisma } = harness();
+    prisma.verificationToken.deleteMany.mockResolvedValueOnce({ count: 3 });
+
+    await expect(service.purgeExpiredVerificationTokens()).resolves.toBe(3);
   });
 
   it('creates a separate session on valid login', async () => {

--- a/RythmRun_backend_nodejs/src/__tests__/user-controller-verify.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/user-controller-verify.test.ts
@@ -1,0 +1,131 @@
+import 'reflect-metadata';
+import { jest } from '@jest/globals';
+
+import { UserController } from '../controllers/user.controller.js';
+import {
+  invalidVerificationTokenError,
+  verificationRateLimitedError,
+} from '../errors/auth.error.js';
+
+interface FakeResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body?: unknown;
+  setHeader: jest.Mock;
+  status: jest.Mock;
+  type: jest.Mock;
+  send: jest.Mock;
+  json: jest.Mock;
+}
+
+function fakeResponse(): FakeResponse {
+  const res = {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+  } as FakeResponse;
+  res.setHeader = jest.fn((key: string, value: string) => {
+    res.headers[key] = value;
+  });
+  res.status = jest.fn((code: number) => {
+    res.statusCode = code;
+    return res;
+  });
+  res.type = jest.fn(() => res);
+  res.send = jest.fn((body: unknown) => {
+    res.body = body;
+    return res;
+  });
+  res.json = jest.fn((body: unknown) => {
+    res.body = body;
+    return res;
+  });
+  return res;
+}
+
+describe('UserController email verification', () => {
+  it('renders the success page with hardened headers on a valid token', async () => {
+    const userService = {
+      verifyEmail: jest.fn<() => Promise<string>>().mockResolvedValue('verified'),
+    };
+    const controller = new UserController(userService as never);
+    const res = fakeResponse();
+
+    await controller.verifyEmail({ query: { token: 'raw' } } as never, res as never);
+
+    expect(userService.verifyEmail).toHaveBeenCalledWith('raw');
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Referrer-Policy']).toBe('no-referrer');
+    expect(res.headers['Content-Security-Policy']).toContain("default-src 'none'");
+    expect(String(res.body)).toContain('email address is confirmed');
+  });
+
+  it('renders the already-verified page for a re-clicked link', async () => {
+    const userService = {
+      verifyEmail: jest
+        .fn<() => Promise<string>>()
+        .mockResolvedValue('already_verified'),
+    };
+    const controller = new UserController(userService as never);
+    const res = fakeResponse();
+
+    await controller.verifyEmail({ query: {} } as never, res as never);
+
+    expect(userService.verifyEmail).toHaveBeenCalledWith('');
+    expect(res.statusCode).toBe(200);
+    expect(String(res.body)).toContain('already confirmed');
+  });
+
+  it('renders the error page and mirrors the status for an invalid token', async () => {
+    const userService = {
+      verifyEmail: jest
+        .fn<() => Promise<string>>()
+        .mockRejectedValue(invalidVerificationTokenError()),
+    };
+    const controller = new UserController(userService as never);
+    const res = fakeResponse();
+
+    await controller.verifyEmail({ query: { token: 'x' } } as never, res as never);
+
+    expect(res.statusCode).toBe(410);
+    expect(res.headers['Referrer-Policy']).toBe('no-referrer');
+    expect(String(res.body)).toContain('invalid or has expired');
+  });
+
+  it('acknowledges a resend generically for the authenticated user', async () => {
+    const userService = {
+      resendVerification: jest
+        .fn<() => Promise<void>>()
+        .mockResolvedValue(undefined),
+    };
+    const controller = new UserController(userService as never);
+    const res = fakeResponse();
+
+    await controller.resendVerification(
+      { user: { id: 7 } } as never,
+      res as never,
+    );
+
+    expect(userService.resendVerification).toHaveBeenCalledWith(7);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('maps a resend rate-limit to a 429 response', async () => {
+    const userService = {
+      resendVerification: jest
+        .fn<() => Promise<void>>()
+        .mockRejectedValue(verificationRateLimitedError()),
+    };
+    const controller = new UserController(userService as never);
+    const res = fakeResponse();
+
+    await controller.resendVerification(
+      { user: { id: 7 } } as never,
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(429);
+    expect((res.body as { error: string }).error).toBe(
+      'AUTH_VERIFICATION_RATE_LIMITED',
+    );
+  });
+});

--- a/RythmRun_backend_nodejs/src/__tests__/user-input-hardening.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/user-input-hardening.test.ts
@@ -198,6 +198,9 @@ describe('UserService writable-field mapping', () => {
         const transaction = {
             user: {
                 create: jest.fn().mockResolvedValue(persistedUser)
+            },
+            verificationToken: {
+                upsert: jest.fn().mockResolvedValue({})
             }
         };
         const authSessions = createMockAuthSessions(transaction);

--- a/RythmRun_backend_nodejs/src/__tests__/user-routes.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/user-routes.test.ts
@@ -5,6 +5,8 @@ const mockUserController = {
   register: jest.fn(),
   login: jest.fn(),
   googleAuth: jest.fn(),
+  verifyEmail: jest.fn(),
+  resendVerification: jest.fn(),
   logout: jest.fn(),
   refreshToken: jest.fn(),
   me: jest.fn(),
@@ -40,11 +42,13 @@ describe('user routes', () => {
       '/register',
       '/login',
       '/auth/google',
+      '/verify-email',
       '/logout',
       '/me',
       '/refresh-token',
       '/profile',
       '/change-password',
+      '/verify-email/resend',
     ]);
     expect(routePaths).not.toContain('/profile-picture');
     expect(routePaths).not.toContain('/profile-picture/:id');

--- a/RythmRun_backend_nodejs/src/controllers/user.controller.ts
+++ b/RythmRun_backend_nodejs/src/controllers/user.controller.ts
@@ -18,6 +18,7 @@ import {
   UpdateProfileDto,
 } from '../models/dto/user.dto.js';
 import { UserService } from '../services/user.service.js';
+import { renderVerifyPage } from '../templates/verify-page.template.js';
 
 interface ErrorResponseOptions {
   validationCode: string;
@@ -132,6 +133,53 @@ export class UserController {
       sendError(res, error, {
         validationCode: 'LOGOUT_FAILED',
         unexpectedOperation: 'Logout',
+      });
+    }
+  };
+
+  verifyEmail = async (req: Request, res: Response): Promise<void> => {
+    // Public, human-facing HTML route. Tighten CSP for this static page and
+    // strip the Referer so the token in the URL cannot leak to any origin.
+    res.setHeader(
+      'Content-Security-Policy',
+      "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'",
+    );
+    res.setHeader('Referrer-Policy', 'no-referrer');
+
+    const token =
+      typeof req.query.token === 'string' ? req.query.token : '';
+    try {
+      const result = await this.userService.verifyEmail(token);
+      res
+        .status(200)
+        .type('html')
+        .send(
+          renderVerifyPage(result === 'already_verified' ? 'already' : 'success'),
+        );
+    } catch (error: unknown) {
+      if (!(error instanceof AuthApplicationError)) {
+        const category = error instanceof Error ? error.name : 'UnknownError';
+        console.error(`Email verification failed (${category})`);
+      }
+      const statusCode =
+        error instanceof AuthApplicationError ? error.statusCode : 500;
+      res.status(statusCode).type('html').send(renderVerifyPage('error'));
+    }
+  };
+
+  resendVerification = async (req: Request, res: Response): Promise<void> => {
+    try {
+      await this.userService.resendVerification(req.user!.id);
+      res.status(200).json({
+        message:
+          'If your email is not yet verified, a new verification link has been sent.',
+        statusCode: 200,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error: unknown) {
+      sendError(res, error, {
+        validationCode: 'VERIFICATION_RESEND_FAILED',
+        unexpectedOperation: 'Verification resend',
       });
     }
   };

--- a/RythmRun_backend_nodejs/src/routes/user.routes.ts
+++ b/RythmRun_backend_nodejs/src/routes/user.routes.ts
@@ -8,6 +8,8 @@ export interface UserRouteController {
   register: RequestHandler;
   login: RequestHandler;
   googleAuth: RequestHandler;
+  verifyEmail: RequestHandler;
+  resendVerification: RequestHandler;
   logout: RequestHandler;
   refreshToken: RequestHandler;
   me: RequestHandler;
@@ -57,6 +59,14 @@ export function createUserRouter({
   router.post('/auth/google', controller.googleAuth);
 
   /**
+   * @route GET /api/users/verify-email
+   * @description Consume an email verification token from a link (public).
+   * @query {string} token - the raw verification token
+   * @returns {text/html} A human-facing verification result page
+   */
+  router.get('/verify-email', controller.verifyEmail);
+
+  /**
    * @route POST /api/users/logout
    * @description Logout user and invalidate refresh token
    * @auth Required
@@ -98,6 +108,18 @@ export function createUserRouter({
    * @returns {Object} Success message
    */
   router.put('/change-password', authenticate, controller.changePassword);
+
+  /**
+   * @route POST /api/users/verify-email/resend
+   * @description Re-send the verification email for the authenticated user.
+   * @auth Required
+   * @returns {Object} Generic acknowledgement (throttled server-side)
+   */
+  router.post(
+    '/verify-email/resend',
+    authenticate,
+    controller.resendVerification,
+  );
 
   return router;
 }

--- a/RythmRun_backend_nodejs/src/server.ts
+++ b/RythmRun_backend_nodejs/src/server.ts
@@ -10,6 +10,7 @@ import type { DatabaseRuntime } from './config/database.js';
 import type { ActivityImageService } from './services/activity-image.service.js';
 import type { AvatarService } from './services/avatar.service.js';
 import type { AuthSessionService } from './services/auth-session.service.js';
+import type { UserService } from './services/user.service.js';
 
 export interface StartServerOptions {
   host?: string;
@@ -184,6 +185,12 @@ export async function startServer(
         container
           .resolve<AuthSessionService>('AuthSessionService')
           .purgeExpiredSessions()
+          .then(() => undefined),
+      );
+      runRetry('Expired verification token cleanup', () =>
+        container
+          .resolve<UserService>('UserService')
+          .purgeExpiredVerificationTokens()
           .then(() => undefined),
       );
     }, options.retryIntervalMs ?? 15 * 60 * 1000);

--- a/RythmRun_backend_nodejs/src/services/user.service.ts
+++ b/RythmRun_backend_nodejs/src/services/user.service.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'node:crypto';
+
 import * as bcrypt from 'bcrypt';
 import { inject, injectable } from 'tsyringe';
 
@@ -5,9 +7,11 @@ import {
   AuthApplicationError,
   googleAccountConflictError,
   invalidCredentialsError,
+  invalidVerificationTokenError,
   passwordUnavailableError,
+  verificationRateLimitedError,
 } from '../errors/auth.error.js';
-import type { PrismaClient } from '../generated/prisma/client.js';
+import { Prisma, type PrismaClient } from '../generated/prisma/client.js';
 import {
   ChangePasswordDto,
   GoogleAuthDto,
@@ -19,11 +23,18 @@ import {
   AuthSessionService,
   type AuthResponse,
   type SafeUserResponse,
+  digestRefreshToken,
   toSafeUserResponse,
 } from './auth-session.service.js';
+import type { EmailSender } from './email.service.js';
 import type { GoogleIdentityVerifier } from './google-auth.service.js';
 
 const SALT_ROUNDS = 10;
+const VERIFICATION_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
+const VERIFICATION_RESEND_COOLDOWN_MS = 60 * 1000;
+const EMAIL_VERIFICATION_PURPOSE = 'EMAIL_VERIFICATION' as const;
+
+export type EmailVerificationResult = 'verified' | 'already_verified';
 
 function canonicalizeUsername(username: string): string {
   return username.trim().toLowerCase();
@@ -55,14 +66,22 @@ export class UserService {
     private readonly authSessions: AuthSessionService,
     @inject('GoogleIdentityVerifier')
     private readonly googleIdentityVerifier?: GoogleIdentityVerifier,
+    @inject('EmailSender')
+    private readonly emailSender?: EmailSender,
   ) {}
 
   async register(registerDto: RegisterUserDto): Promise<AuthResponse> {
     const hashedPassword = await bcrypt.hash(registerDto.password, SALT_ROUNDS);
     const username = canonicalizeUsername(registerDto.username);
 
+    let registration: {
+      response: AuthResponse;
+      username: string;
+      firstname: string | null;
+      rawToken: string;
+    };
     try {
-      return await this.authSessions.withSerializableTransaction(
+      registration = await this.authSessions.withSerializableTransaction(
         async (transaction) => {
           const user = await transaction.user.create({
             data: {
@@ -72,10 +91,23 @@ export class UserService {
               lastname: registerDto.lastname,
             },
           });
-          return this.authSessions.issueSessionInTransaction(
+          const response = await this.authSessions.issueSessionInTransaction(
             transaction,
             user,
           );
+          // Cheap, atomic DB work only; the SMTP call stays out of the
+          // serializable transaction (it retries on P2034 and its latency
+          // would hold locks / risk duplicate sends).
+          const rawToken = await this.issueVerificationToken(
+            transaction,
+            user.id,
+          );
+          return {
+            response,
+            username: user.username,
+            firstname: user.firstname,
+            rawToken,
+          };
         },
       );
     } catch (error: unknown) {
@@ -93,6 +125,174 @@ export class UserService {
         }
       }
       throw error;
+    }
+
+    // Post-commit and best-effort: a send failure must never roll back an
+    // already-registered user, who still receives a session either way.
+    await this.deliverVerificationEmail(
+      registration.username,
+      registration.firstname,
+      registration.rawToken,
+    );
+    return registration.response;
+  }
+
+  /**
+   * Verifies an email using the raw token from a verification link. The
+   * state transition is a single atomic update; re-presenting a consumed
+   * token for an already-verified user is idempotent success (email
+   * scanners and browsers routinely prefetch the GET link).
+   */
+  async verifyEmail(rawToken: string): Promise<EmailVerificationResult> {
+    if (typeof rawToken !== 'string' || rawToken.length === 0) {
+      throw invalidVerificationTokenError();
+    }
+    const tokenDigest = digestRefreshToken(rawToken);
+
+    const outcome = await this.authSessions.withSerializableTransaction(
+      async (transaction) => {
+        const now = new Date();
+        const token = await transaction.verificationToken.findUnique({
+          where: { tokenDigest },
+        });
+        if (token === null) {
+          return 'invalid' as const;
+        }
+
+        if (token.consumedAt !== null) {
+          const owner = await transaction.user.findUnique({
+            where: { id: token.userId },
+            select: { emailVerified: true },
+          });
+          return owner?.emailVerified === true
+            ? ('already_verified' as const)
+            : ('invalid' as const);
+        }
+
+        const consumed = await transaction.verificationToken.updateMany({
+          where: {
+            tokenDigest,
+            consumedAt: null,
+            expiresAt: { gt: now },
+          },
+          data: { consumedAt: now },
+        });
+        if (consumed.count !== 1) {
+          return 'invalid' as const;
+        }
+
+        await transaction.user.update({
+          where: { id: token.userId },
+          data: { emailVerified: true },
+        });
+        return 'verified' as const;
+      },
+    );
+
+    if (outcome === 'invalid') {
+      throw invalidVerificationTokenError();
+    }
+    return outcome;
+  }
+
+  /**
+   * Re-sends the verification link for the authenticated owner. No-op when
+   * already verified; DB-backed per-account cooldown throttles abuse; a
+   * resend rotates the single outstanding token so old links stop working.
+   */
+  async resendVerification(userId: number): Promise<void> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (user === null) {
+      throw new AuthApplicationError(
+        'AUTH_USER_NOT_FOUND',
+        404,
+        'User account was not found',
+      );
+    }
+    if (user.emailVerified) {
+      return;
+    }
+
+    const existing = await this.prisma.verificationToken.findUnique({
+      where: {
+        userId_purpose: { userId, purpose: EMAIL_VERIFICATION_PURPOSE },
+      },
+      select: { lastSentAt: true },
+    });
+    if (
+      existing?.lastSentAt != null &&
+      Date.now() - existing.lastSentAt.getTime() <
+        VERIFICATION_RESEND_COOLDOWN_MS
+    ) {
+      throw verificationRateLimitedError();
+    }
+
+    const rawToken = await this.authSessions.withSerializableTransaction(
+      (transaction) => this.issueVerificationToken(transaction, userId),
+    );
+    await this.deliverVerificationEmail(
+      user.username,
+      user.firstname,
+      rawToken,
+    );
+  }
+
+  async purgeExpiredVerificationTokens(now = new Date()): Promise<number> {
+    const result = await this.prisma.verificationToken.deleteMany({
+      where: { expiresAt: { lte: now } },
+    });
+    return result.count;
+  }
+
+  /**
+   * Issues (or rotates) the single outstanding verification token for a user
+   * inside an existing transaction. Only the SHA-256 digest is stored; the
+   * returned raw token exists solely to be emailed.
+   */
+  private async issueVerificationToken(
+    transaction: Prisma.TransactionClient,
+    userId: number,
+    now = new Date(),
+  ): Promise<string> {
+    const rawToken = randomBytes(32).toString('base64url');
+    const tokenDigest = digestRefreshToken(rawToken);
+    const expiresAt = new Date(now.getTime() + VERIFICATION_TOKEN_TTL_MS);
+
+    await transaction.verificationToken.upsert({
+      where: {
+        userId_purpose: { userId, purpose: EMAIL_VERIFICATION_PURPOSE },
+      },
+      create: {
+        userId,
+        purpose: EMAIL_VERIFICATION_PURPOSE,
+        tokenDigest,
+        expiresAt,
+        lastSentAt: now,
+      },
+      update: {
+        tokenDigest,
+        expiresAt,
+        consumedAt: null,
+        lastSentAt: now,
+      },
+    });
+    return rawToken;
+  }
+
+  private async deliverVerificationEmail(
+    to: string,
+    firstname: string | null,
+    rawToken: string,
+  ): Promise<void> {
+    if (this.emailSender === undefined || !this.emailSender.enabled) {
+      return;
+    }
+    try {
+      await this.emailSender.sendEmailVerification({ to, firstname, rawToken });
+    } catch (error: unknown) {
+      // Never log the token or recipient (PII); only the error category.
+      const category = error instanceof Error ? error.name : 'UnknownError';
+      console.error(`Verification email send failed (${category})`);
     }
   }
 

--- a/RythmRun_backend_nodejs/src/templates/verify-page.template.ts
+++ b/RythmRun_backend_nodejs/src/templates/verify-page.template.ts
@@ -1,0 +1,69 @@
+export type VerifyPageState = 'success' | 'already' | 'error';
+
+interface VerifyPageCopy {
+  title: string;
+  heading: string;
+  body: string;
+  accent: string;
+}
+
+const COPY: Record<VerifyPageState, VerifyPageCopy> = {
+  success: {
+    title: 'Email verified',
+    heading: 'Email verified',
+    body: 'Your email address is confirmed. You can return to the RythmRun app and continue.',
+    accent: '#0e9c74',
+  },
+  already: {
+    title: 'Already verified',
+    heading: 'Already verified',
+    body: 'This email address is already confirmed. You can return to the RythmRun app.',
+    accent: '#0e9c74',
+  },
+  error: {
+    title: 'Link invalid or expired',
+    heading: 'This link didn’t work',
+    body: 'The verification link is invalid or has expired. Open the RythmRun app and request a new verification email.',
+    accent: '#d1435b',
+  },
+};
+
+/**
+ * Renders a static, self-contained verification result page. No user input is
+ * interpolated, so inline styles are safe. This route is served with a tight
+ * per-response CSP (default-src 'none'; style-src 'unsafe-inline') and
+ * Referrer-Policy: no-referrer so the token in the URL cannot leak.
+ */
+export function renderVerifyPage(state: VerifyPageState): string {
+  const copy = COPY[state];
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>${copy.title} · RythmRun</title>
+    <style>
+      body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
+        background: #f5f6f8; color: #14181d;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; }
+      .card { background: #ffffff; max-width: 420px; margin: 16px; padding: 40px 32px; border-radius: 16px;
+        box-shadow: 0 8px 30px rgba(20,24,29,0.08); text-align: center; }
+      .brand { font-size: 14px; font-weight: 700; letter-spacing: 0.02em; color: #667079; margin-bottom: 20px; }
+      .mark { width: 56px; height: 56px; border-radius: 50%; margin: 0 auto 20px;
+        display: flex; align-items: center; justify-content: center; font-size: 28px; color: #ffffff;
+        background: ${copy.accent}; }
+      h1 { font-size: 22px; margin: 0 0 12px; letter-spacing: -0.01em; }
+      p { font-size: 15px; line-height: 1.6; color: #3d454e; margin: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <div class="brand">RythmRun</div>
+      <div class="mark">${state === 'error' ? '!' : '✓'}</div>
+      <h1>${copy.heading}</h1>
+      <p>${copy.body}</p>
+    </main>
+  </body>
+</html>`;
+}


### PR DESCRIPTION
Wires the verification flow end to end (still gates nothing but the future auto-merge; login and registration are unchanged for unverified users).

- register() issues a single-use hashed token inside the existing serializable transaction and sends the email POST-COMMIT, best-effort: an SMTP failure is logged (no token/recipient PII) and never rolls back the registered user or fails the request.
- verifyEmail(): atomic single-use consume; idempotent when a consumed token is re-presented for an already-verified user, so email-scanner/browser GET prefetch does not surface a false "invalid link".
- resendVerification(): authenticated owner-only, no-op when already verified, DB-backed per-account cooldown, rotates the one outstanding token.
- Public GET /api/users/verify-email renders a branded HTML result page with a tightened per-response CSP and Referrer-Policy: no-referrer so the URL token cannot leak; authenticated POST /verify-email/resend.
- Expired verification tokens purged on the existing 15-minute sweep timer.