### PR TITLE
feat(auth): safely auto-link Google to verified existing accounts

### DIFF
--- a/RythmRun_backend_nodejs/src/__tests__/auth-session.postgres.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/auth-session.postgres.test.ts
@@ -243,7 +243,9 @@ integrationDescribe('auth sessions on PostgreSQL', () => {
     await expect(
       conflictingGoogleUsers.googleLogin({ idToken: 'test-verifier-token' }),
     ).rejects.toMatchObject({
-      code: 'AUTH_GOOGLE_ACCOUNT_CONFLICT',
+      // The collision account registered by password is unverified, so an
+      // auto-merge is refused with the email-unverified conflict.
+      code: 'AUTH_EMAIL_UNVERIFIED_CONFLICT',
       statusCode: 409,
     });
   });

--- a/RythmRun_backend_nodejs/src/__tests__/user-auth.service.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/user-auth.service.test.ts
@@ -351,6 +351,7 @@ describe('UserService authentication lifecycle', () => {
         username: googleIdentity.email,
         password: null,
         googleSubject: googleIdentity.subject,
+        emailVerified: true,
         firstname: googleIdentity.firstname,
         lastname: googleIdentity.lastname,
       },
@@ -382,22 +383,25 @@ describe('UserService authentication lifecycle', () => {
     );
   });
 
-  it('does not auto-link a Google identity to an existing email account', async () => {
+  it('refuses to link Google to an unverified existing email account', async () => {
     const { service, transaction, authSessions } = harness();
     transaction.user.findUnique.mockResolvedValueOnce(null);
     transaction.user.findFirst.mockResolvedValueOnce({
       ...user,
       username: 'Google.Runner@Example.com',
+      emailVerified: false,
+      googleSubject: null,
     });
 
     await expect(
       service.googleLogin({ idToken: 'google-id-token' }),
     ).rejects.toMatchObject({
-      code: 'AUTH_GOOGLE_ACCOUNT_CONFLICT',
+      code: 'AUTH_EMAIL_UNVERIFIED_CONFLICT',
       statusCode: 409,
     });
 
     expect(transaction.user.create).not.toHaveBeenCalled();
+    expect(transaction.user.updateMany).not.toHaveBeenCalled();
     expect(transaction.user.findFirst).toHaveBeenCalledWith({
       where: {
         username: {
@@ -406,6 +410,60 @@ describe('UserService authentication lifecycle', () => {
         },
       },
     });
+    expect(authSessions.issueSessionInTransaction).not.toHaveBeenCalled();
+  });
+
+  it('auto-links Google to a verified email account and revokes other sessions', async () => {
+    const { service, transaction, authSessions } = harness();
+    const verifiedOwner = {
+      ...user,
+      username: googleIdentity.email,
+      emailVerified: true,
+      googleSubject: null,
+    };
+    transaction.user.findUnique.mockResolvedValueOnce(null);
+    transaction.user.findFirst.mockResolvedValueOnce(verifiedOwner);
+    transaction.user.updateMany.mockResolvedValueOnce({ count: 1 });
+    authSessions.issueSessionInTransaction.mockResolvedValueOnce(
+      googleAuthResponse,
+    );
+
+    await expect(
+      service.googleLogin({ idToken: 'google-id-token' }),
+    ).resolves.toEqual(googleAuthResponse);
+
+    expect(transaction.user.updateMany).toHaveBeenCalledWith({
+      where: { id: verifiedOwner.id, googleSubject: null },
+      data: { googleSubject: googleIdentity.subject },
+    });
+    expect(
+      authSessions.revokeAllUserSessionsInTransaction,
+    ).toHaveBeenCalledWith(transaction, verifiedOwner.id);
+    expect(transaction.user.create).not.toHaveBeenCalled();
+    expect(authSessions.issueSessionInTransaction).toHaveBeenCalledWith(
+      transaction,
+      { ...verifiedOwner, googleSubject: googleIdentity.subject },
+    );
+  });
+
+  it('keeps a hard conflict when a verified account is already linked', async () => {
+    const { service, transaction, authSessions } = harness();
+    transaction.user.findUnique.mockResolvedValueOnce(null);
+    transaction.user.findFirst.mockResolvedValueOnce({
+      ...user,
+      username: googleIdentity.email,
+      emailVerified: true,
+      googleSubject: 'a-different-google-subject',
+    });
+
+    await expect(
+      service.googleLogin({ idToken: 'google-id-token' }),
+    ).rejects.toMatchObject({
+      code: 'AUTH_EMAIL_UNVERIFIED_CONFLICT',
+      statusCode: 409,
+    });
+
+    expect(transaction.user.updateMany).not.toHaveBeenCalled();
     expect(authSessions.issueSessionInTransaction).not.toHaveBeenCalled();
   });
 

--- a/RythmRun_backend_nodejs/src/services/user.service.ts
+++ b/RythmRun_backend_nodejs/src/services/user.service.ts
@@ -5,6 +5,7 @@ import { inject, injectable } from 'tsyringe';
 
 import {
   AuthApplicationError,
+  emailUnverifiedConflictError,
   googleAccountConflictError,
   invalidCredentialsError,
   invalidVerificationTokenError,
@@ -357,9 +358,14 @@ export class UserService {
             );
           }
 
-          // A matching password account is not linked implicitly. Linking by
-          // email alone could attach a Google identity to the wrong account;
-          // an explicit, authenticated linking flow can be added separately.
+          // Safe automatic linking: a Google sign-in may merge onto an
+          // existing local account ONLY when that account has independently
+          // proven control of this email (emailVerified === true) and is not
+          // already linked to a Google identity. Google itself already
+          // enforced email_verified === true, so both sides then prove the
+          // same mailbox and the link is safe. Any other case stays a hard
+          // conflict — auto-linking an unverified account would let an
+          // attacker pre-hijack it.
           const emailOwner = await transaction.user.findFirst({
             where: {
               username: {
@@ -369,7 +375,28 @@ export class UserService {
             },
           });
           if (emailOwner !== null) {
-            throw googleAccountConflictError();
+            if (
+              emailOwner.emailVerified === true &&
+              emailOwner.googleSubject === null
+            ) {
+              const linked = await transaction.user.updateMany({
+                where: { id: emailOwner.id, googleSubject: null },
+                data: { googleSubject: identity.subject },
+              });
+              if (linked.count === 1) {
+                // Attaching a new sign-in method invalidates the account's
+                // other sessions, mirroring a password change.
+                await this.authSessions.revokeAllUserSessionsInTransaction(
+                  transaction,
+                  emailOwner.id,
+                );
+                return this.authSessions.issueSessionInTransaction(
+                  transaction,
+                  { ...emailOwner, googleSubject: identity.subject },
+                );
+              }
+            }
+            throw emailUnverifiedConflictError();
           }
 
           const user = await transaction.user.create({
@@ -377,6 +404,10 @@ export class UserService {
               username: identity.email,
               password: null,
               googleSubject: identity.subject,
+              // Google already enforced email_verified === true, so a new
+              // Google-origin account is verified at creation and needs no
+              // verification email.
+              emailVerified: true,
               firstname: identity.firstname,
               lastname: identity.lastname,
             },


### PR DESCRIPTION
Turns the previous hard conflict on a same-email Google sign-in into a guarded automatic merge, closing the account pre-hijacking risk.

- googleLogin() merges a Google identity onto an existing local account ONLY when that account has proven control of the email (emailVerified === true) AND is not already linked (googleSubject === null). The link uses a race-safe updateMany ... WHERE googleSubject IS NULL with a count check, and revokes the account's other sessions on link (mirrors changePassword).
- Any other collision (unverified, or already linked to another subject) is refused with the new AUTH_EMAIL_UNVERIFIED_CONFLICT (409) so the client can prompt 'sign in with your password and verify first' instead of a generic 'account exists'.
- New Google-origin accounts are created with emailVerified: true (Google already enforced email_verified === true) and get no verification email.

Both sides now independently prove the same mailbox before a merge.