### PR TITLE
feat(auth): carry emailVerified through the client and add resend API

### DIFF
--- a/rythmrun_frontend_flutter/lib/core/config/api_endpoints.dart
+++ b/rythmrun_frontend_flutter/lib/core/config/api_endpoints.dart
@@ -9,6 +9,7 @@ class ApiEndpoints {
   static const String me = '/users/me';
   static const String profile = '/users/profile';
   static const String changePassword = '/users/change-password';
+  static const String resendVerification = '/users/verify-email/resend';
 
   // Activity endpoints
   static const String activities = '/activities';

--- a/rythmrun_frontend_flutter/lib/core/services/auth_persistence_service.dart
+++ b/rythmrun_frontend_flutter/lib/core/services/auth_persistence_service.dart
@@ -177,6 +177,9 @@ class AuthPersistenceService {
         lastName: decoded['lastName'] as String,
         email: decoded['email'] as String,
         hasPassword: decoded['hasPassword'] as bool? ?? true,
+        // Same default as UserModel.fromJson: a blob cached before this field
+        // existed must not flash an "unverified" banner.
+        emailVerified: decoded['emailVerified'] as bool? ?? true,
         profilePicturePath: decoded['profilePicturePath'] as String?,
         profilePictureType: decoded['profilePictureType'] as String?,
         createdAt:
@@ -285,6 +288,7 @@ class AuthPersistenceService {
         'lastName': user.lastName,
         'email': user.email,
         'hasPassword': user.hasPassword,
+        'emailVerified': user.emailVerified,
         'profilePicturePath': user.profilePicturePath,
         'profilePictureType': user.profilePictureType,
         'createdAt': user.createdAt?.toIso8601String(),

--- a/rythmrun_frontend_flutter/lib/core/utils/error_handler.dart
+++ b/rythmrun_frontend_flutter/lib/core/utils/error_handler.dart
@@ -15,6 +15,12 @@ class ErrorHandler {
           return 'Google sign-in could not be verified. Please choose your account and try again.';
         case 'AUTH_GOOGLE_ACCOUNT_CONFLICT':
           return 'A RythmRun account already exists for this email. Sign in with its original method.';
+        case 'AUTH_EMAIL_UNVERIFIED_CONFLICT':
+          return 'An account already exists for this email. Sign in with your password and verify your email, then Google sign-in will link automatically.';
+        case 'AUTH_VERIFICATION_TOKEN_INVALID':
+          return 'This verification link is invalid or has expired. Request a new one.';
+        case 'AUTH_VERIFICATION_RATE_LIMITED':
+          return 'Please wait a moment before requesting another verification email.';
       }
     }
 

--- a/rythmrun_frontend_flutter/lib/data/datasources/auth_remote_datasource.dart
+++ b/rythmrun_frontend_flutter/lib/data/datasources/auth_remote_datasource.dart
@@ -131,6 +131,41 @@ class AuthRemoteDataSource {
     return response.statusCode == 200;
   }
 
+  /// Fetch the server's current safe user.
+  ///
+  /// [verifySession] deliberately returns only a boolean, so it cannot observe
+  /// server-side state changes. This parses the body instead, which is what
+  /// lets the client notice an email that was verified on another device.
+  Future<UserModel> fetchCurrentUser(Map<String, String> authHeaders) async {
+    final headers = <String, String>{
+      'Content-Type': 'application/json',
+      ...authHeaders,
+    };
+
+    final response = await _httpClient.get(
+      _resolveEndpoint(ApiEndpoints.me),
+      headers: headers,
+    );
+
+    final Map<String, dynamic> jsonResponse = json.decode(response.body);
+    return UserModel.fromJson(jsonResponse);
+  }
+
+  /// Ask the backend to re-send the verification email for the signed-in user.
+  /// The server throttles this and answers generically.
+  Future<void> resendVerificationEmail(Map<String, String> authHeaders) async {
+    final headers = <String, String>{
+      'Content-Type': 'application/json',
+      ...authHeaders,
+    };
+
+    await _httpClient.post(
+      _resolveEndpoint(ApiEndpoints.resendVerification),
+      headers: headers,
+      maxRetries: 0,
+    );
+  }
+
   /// Update first/last name and return the server's updated safe user.
   Future<UserModel> updateProfile(
     String firstName,

--- a/rythmrun_frontend_flutter/lib/data/models/user_model.dart
+++ b/rythmrun_frontend_flutter/lib/data/models/user_model.dart
@@ -7,6 +7,7 @@ class UserModel extends UserEntity {
     required super.lastName,
     required super.email,
     super.hasPassword,
+    super.emailVerified,
     super.profilePicturePath,
     super.profilePictureType,
     super.createdAt,
@@ -19,6 +20,9 @@ class UserModel extends UserEntity {
       lastName: json['lastname'] ?? '', // Backend uses lowercase
       email: json['username'] ?? '', // Backend uses username field for email
       hasPassword: json['hasPassword'] as bool? ?? true,
+      // Defaults true so an older API that omits the field never flags an
+      // existing account as unverified.
+      emailVerified: json['emailVerified'] as bool? ?? true,
       profilePicturePath:
           json['profilePicturePath'] as String?, // Profile picture S3 key
       profilePictureType:
@@ -34,6 +38,7 @@ class UserModel extends UserEntity {
       'lastName': lastName,
       'email': email,
       'hasPassword': hasPassword,
+      'emailVerified': emailVerified,
       'profilePicturePath': profilePicturePath,
       'profilePictureType': profilePictureType,
       'createdAt': createdAt?.toIso8601String(),
@@ -47,6 +52,7 @@ class UserModel extends UserEntity {
       lastName: entity.lastName,
       email: entity.email,
       hasPassword: entity.hasPassword,
+      emailVerified: entity.emailVerified,
       profilePicturePath: entity.profilePicturePath,
       profilePictureType: entity.profilePictureType,
       createdAt: entity.createdAt,
@@ -60,6 +66,7 @@ class UserModel extends UserEntity {
       lastName: lastName,
       email: email,
       hasPassword: hasPassword,
+      emailVerified: emailVerified,
       profilePicturePath: profilePicturePath,
       profilePictureType: profilePictureType,
       createdAt: createdAt,

--- a/rythmrun_frontend_flutter/lib/domain/entities/user_entity.dart
+++ b/rythmrun_frontend_flutter/lib/domain/entities/user_entity.dart
@@ -6,6 +6,15 @@ class UserEntity {
   final String lastName;
   final String email;
   final bool hasPassword;
+
+  /// Whether the account has proven control of its email address.
+  ///
+  /// Defaults to true everywhere it is deserialized so that a response or a
+  /// cached blob written before this field existed never shows a spurious
+  /// "verify your email" banner. This value is presentation-only: the server
+  /// alone decides verification-gated behaviour such as Google account
+  /// linking, and never trusts a client-supplied value.
+  final bool emailVerified;
   final String? profilePicturePath; // Keep for backward compatibility
   final String? profilePictureType;
   final DateTime? createdAt;
@@ -16,6 +25,7 @@ class UserEntity {
     required this.lastName,
     required this.email,
     this.hasPassword = true,
+    this.emailVerified = true,
     this.profilePicturePath,
     this.profilePictureType,
     this.createdAt,
@@ -27,6 +37,7 @@ class UserEntity {
     String? lastName,
     String? email,
     bool? hasPassword,
+    bool? emailVerified,
     Object? profilePicturePath = _unset,
     Object? profilePictureType = _unset,
     Object? createdAt = _unset,
@@ -37,6 +48,7 @@ class UserEntity {
       lastName: lastName ?? this.lastName,
       email: email ?? this.email,
       hasPassword: hasPassword ?? this.hasPassword,
+      emailVerified: emailVerified ?? this.emailVerified,
       profilePicturePath:
           identical(profilePicturePath, _unset)
               ? this.profilePicturePath
@@ -64,6 +76,7 @@ class UserEntity {
           lastName == other.lastName &&
           email == other.email &&
           hasPassword == other.hasPassword &&
+          emailVerified == other.emailVerified &&
           profilePicturePath == other.profilePicturePath &&
           profilePictureType == other.profilePictureType;
 
@@ -74,11 +87,12 @@ class UserEntity {
       lastName.hashCode ^
       email.hashCode ^
       hasPassword.hashCode ^
+      emailVerified.hashCode ^
       profilePicturePath.hashCode ^
       profilePictureType.hashCode;
 
   @override
   String toString() {
-    return 'UserEntity{id: $id, hasPassword: $hasPassword, hasProfilePicture: ${profilePicturePath != null}, createdAt: $createdAt}';
+    return 'UserEntity{id: $id, hasPassword: $hasPassword, emailVerified: $emailVerified, hasProfilePicture: ${profilePicturePath != null}, createdAt: $createdAt}';
   }
 }

--- a/rythmrun_frontend_flutter/test/core/services/auth_persistence_service_test.dart
+++ b/rythmrun_frontend_flutter/test/core/services/auth_persistence_service_test.dart
@@ -244,6 +244,39 @@ void main() {
     expect((await persistence.getUserData())?.hasPassword, isTrue);
   });
 
+  test('older cached users default to email-verified', () async {
+    final persistence = service(
+      secure: _MemorySecureValueStore(),
+      preferences: _MemoryPreferences(<String, Object>{
+        AuthPersistenceService.userDataKey: _encodedUser,
+      }),
+    );
+
+    // A blob cached before the field existed must not look unverified.
+    expect((await persistence.getUserData())?.emailVerified, isTrue);
+  });
+
+  test('locally rewritten users keep an unverified email flag', () async {
+    final persistence = service(
+      secure: _MemorySecureValueStore(),
+      preferences: _MemoryPreferences(),
+    );
+
+    await persistence.updateUserData(
+      const UserModel(
+        id: '7',
+        firstName: 'Ada',
+        lastName: 'Runner',
+        email: 'runner@example.test',
+        emailVerified: false,
+      ),
+    );
+
+    // updateUserData/getUserData hand-roll their JSON instead of going through
+    // UserModel, so this guards against silently dropping the field.
+    expect((await persistence.getUserData())?.emailVerified, isFalse);
+  });
+
   test('cleanup marker remains until every account value is absent', () async {
     final secure = _MemorySecureValueStore();
     final preferences = _MemoryPreferences();

--- a/rythmrun_frontend_flutter/test/data/models/user_model_test.dart
+++ b/rythmrun_frontend_flutter/test/data/models/user_model_test.dart
@@ -43,4 +43,47 @@ void main() {
     expect(googleUser.hashCode, isNot(passwordUser.hashCode));
     expect(googleUser.copyWith(), googleUser);
   });
+
+  test('parses and round-trips an unverified email', () {
+    final model = UserModel.fromJson(<String, Object?>{
+      'id': 7,
+      'firstname': 'Ada',
+      'lastname': 'Runner',
+      'username': 'runner@example.test',
+      'emailVerified': false,
+    });
+
+    expect(model.emailVerified, isFalse);
+    expect(model.toEntity().emailVerified, isFalse);
+    expect(model.toJson()['emailVerified'], isFalse);
+    expect(UserModel.fromEntity(model).emailVerified, isFalse);
+  });
+
+  test('responses omitting emailVerified default to verified', () {
+    final model = UserModel.fromJson(<String, Object?>{
+      'id': 7,
+      'firstname': 'Legacy',
+      'lastname': 'Runner',
+      'username': 'runner@example.test',
+    });
+
+    // Defaulting to true keeps an older API (or a pre-upgrade cached blob)
+    // from flagging every existing account as unverified.
+    expect(model.emailVerified, isTrue);
+  });
+
+  test('equality and copyWith track the verified flag so the UI rebuilds', () {
+    const verified = UserEntity(
+      id: '7',
+      firstName: 'A',
+      lastName: 'Runner',
+      email: 'runner@example.test',
+    );
+    final unverified = verified.copyWith(emailVerified: false);
+
+    expect(unverified.emailVerified, isFalse);
+    expect(unverified, isNot(verified));
+    expect(unverified.hashCode, isNot(verified.hashCode));
+    expect(unverified.copyWith(emailVerified: true), verified);
+  });
 }


### PR DESCRIPTION
Client-side data model and API contract for email verification. No UI yet.

- UserEntity gains emailVerified across all six members, including == and hashCode so a false -> true transition actually rebuilds dependent widgets.
- UserModel maps it in fromJson/toJson/fromEntity/toEntity, and AuthPersistenceService now carries it in BOTH hand-rolled JSON sites (getUserData/updateUserData) which bypass UserModel and would otherwise silently drop the field on every cached read and local rewrite.
- Every deserialization point defaults to TRUE so an older API response or a pre-upgrade cached blob never shows a spurious verify your email banner. The flag is presentation-only; the server alone gates account linking.
- AuthRemoteDataSource.fetchCurrentUser() parses the /me body (verifySession returns only a bool and cannot observe verification happening elsewhere), plus resendVerificationEmail() and its endpoint.
- ErrorHandler maps AUTH_EMAIL_UNVERIFIED_CONFLICT, AUTH_VERIFICATION_TOKEN_INVALID and AUTH_VERIFICATION_RATE_LIMITED, which would otherwise fall through to a generic permission message.