### PR TITLE
feat(auth): prompt unverified accounts to confirm their email

### DIFF
--- a/rythmrun_frontend_flutter/lib/data/repositories/auth_repository_impl.dart
+++ b/rythmrun_frontend_flutter/lib/data/repositories/auth_repository_impl.dart
@@ -195,6 +195,28 @@ class AuthRepositoryImpl implements AuthRepository {
   }
 
   @override
+  Future<UserEntity> refreshCurrentUser() async {
+    // A read, so it stays allowed offline-guard-free and simply fails if the
+    // network is down. One post-refresh replay is safe for a GET.
+    final user = await _authenticatedRequests.execute(
+      replayPolicy: AuthenticatedReplayPolicy.idempotent,
+      request: _remoteDataSource.fetchCurrentUser,
+    );
+    return user.toEntity();
+  }
+
+  @override
+  Future<void> resendVerificationEmail() async {
+    // Sending mail is an online-only action; the server throttles repeats, so
+    // a single post-refresh replay is safe.
+    _onlineOperationGuard?.requireOnline();
+    await _authenticatedRequests.execute(
+      replayPolicy: AuthenticatedReplayPolicy.idempotent,
+      request: _remoteDataSource.resendVerificationEmail,
+    );
+  }
+
+  @override
   Future<UserEntity> updateProfile({
     required String firstName,
     required String lastName,

--- a/rythmrun_frontend_flutter/lib/domain/repositories/auth_repository.dart
+++ b/rythmrun_frontend_flutter/lib/domain/repositories/auth_repository.dart
@@ -38,6 +38,14 @@ abstract class AuthRepository {
   /// Persist non-secret cached profile metadata for the active user.
   Future<void> updateCurrentUser(UserEntity user);
 
+  /// Read the server's current safe user, including verification state.
+  /// Remote-only: the session coordinator commits visible and cached state.
+  Future<UserEntity> refreshCurrentUser();
+
+  /// Ask the backend to re-send the verification email for the signed-in
+  /// user. The server throttles this and answers generically.
+  Future<void> resendVerificationEmail();
+
   /// Update first/last name on the server and return the updated safe user.
   /// Remote-only: the session coordinator commits visible and cached state.
   Future<UserEntity> updateProfile({

--- a/rythmrun_frontend_flutter/lib/presentation/common/providers/session_provider.dart
+++ b/rythmrun_frontend_flutter/lib/presentation/common/providers/session_provider.dart
@@ -440,6 +440,45 @@ class SessionNotifier extends StateNotifier<SessionData> {
     }
   }
 
+  /// Re-reads the server's email verification state and commits only that flag.
+  ///
+  /// Verification normally completes in a browser, often on another device, so
+  /// the app has no other signal that it happened. Only emailVerified is
+  /// merged; name and avatar stay owned by their own flows, and a response for
+  /// a different or stale owner is discarded rather than applied.
+  Future<void> refreshVerificationState() async {
+    final currentUser = state.user;
+    if (currentUser == null) return;
+
+    final UserEntity serverUser;
+    try {
+      serverUser = await _authRepository.refreshCurrentUser();
+    } catch (_) {
+      // Best effort: a failed refresh simply leaves the banner as it was.
+      return;
+    }
+    if (serverUser.id != currentUser.id) return;
+
+    final latestUser = state.user;
+    if (latestUser == null ||
+        latestUser.id != currentUser.id ||
+        latestUser.emailVerified == serverUser.emailVerified) {
+      return;
+    }
+
+    final committedUser = latestUser.copyWith(
+      emailVerified: serverUser.emailVerified,
+    );
+    state = state.copyWith(user: committedUser);
+    await _authRepository.updateCurrentUser(committedUser);
+  }
+
+  /// Requests another verification email. Errors (including the server-side
+  /// rate limit) propagate so the caller can surface them.
+  Future<void> resendVerificationEmail() {
+    return _authRepository.resendVerificationEmail();
+  }
+
   /// Called to logout user. An active or unsaved workout requires an explicit
   /// decision before credentials or user state are cleared.
   Future<UserScopeTeardownResult> logout({UserScopeExitDecision? decision}) {

--- a/rythmrun_frontend_flutter/lib/presentation/features/home/screens/home_screen.dart
+++ b/rythmrun_frontend_flutter/lib/presentation/features/home/screens/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:rythmrun_frontend_flutter/presentation/features/live_tracking/sc
 import 'package:rythmrun_frontend_flutter/presentation/features/tracking_history/screens/tracking_history_screen.dart';
 import 'package:rythmrun_frontend_flutter/presentation/features/profile/screens/profile_screen.dart';
 import 'package:rythmrun_frontend_flutter/presentation/features/fitness_calculator/screens/fitness_tools_screen.dart';
+import 'package:rythmrun_frontend_flutter/presentation/features/home/widgets/email_verification_banner.dart';
 import 'package:rythmrun_frontend_flutter/theme/app_theme.dart';
 
 // Provider for managing the current tab index
@@ -97,7 +98,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     ];
 
     return Scaffold(
-      body: IndexedStack(index: currentIndex, children: screens),
+      body: Column(
+        children: [
+          // Sits above the tab stack so it is visible from every tab.
+          const EmailVerificationBanner(),
+          Expanded(
+            child: IndexedStack(index: currentIndex, children: screens),
+          ),
+        ],
+      ),
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: currentIndex,
         onTap: (index) {

--- a/rythmrun_frontend_flutter/lib/presentation/features/home/widgets/email_verification_banner.dart
+++ b/rythmrun_frontend_flutter/lib/presentation/features/home/widgets/email_verification_banner.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/utils/error_handler.dart';
+import '../../../common/providers/session_provider.dart';
+
+/// Non-blocking prompt shown when the signed-in account has not yet confirmed
+/// its email address.
+///
+/// Only password accounts ever see this: an account created through Google is
+/// already verified by Google, so nagging it would be both wrong and
+/// unactionable (it has no password flow to fall back on).
+class EmailVerificationBanner extends ConsumerStatefulWidget {
+  const EmailVerificationBanner({super.key});
+
+  @override
+  ConsumerState<EmailVerificationBanner> createState() =>
+      _EmailVerificationBannerState();
+}
+
+class _EmailVerificationBannerState
+    extends ConsumerState<EmailVerificationBanner> {
+  bool _dismissed = false;
+  bool _busy = false;
+  String? _message;
+
+  Future<void> _resend() async {
+    if (_busy) return;
+    setState(() {
+      _busy = true;
+      _message = null;
+    });
+
+    String message;
+    try {
+      await ref.read(sessionProvider.notifier).resendVerificationEmail();
+      message = 'Verification email sent. Check your inbox.';
+    } catch (error) {
+      // Covers the server-side cooldown (429) and offline errors.
+      message = ErrorHandler.getErrorMessage(error);
+    }
+
+    if (!mounted) return;
+    setState(() {
+      _busy = false;
+      _message = message;
+    });
+  }
+
+  Future<void> _refresh() async {
+    if (_busy) return;
+    setState(() {
+      _busy = true;
+      _message = null;
+    });
+
+    await ref.read(sessionProvider.notifier).refreshVerificationState();
+    if (!mounted) return;
+
+    // If it worked, this widget stops rendering on the next build.
+    final stillUnverified = ref.read(currentUserProvider)?.emailVerified == false;
+    setState(() {
+      _busy = false;
+      _message =
+          stillUnverified
+              ? 'Not confirmed yet. Open the link in your email, then try again.'
+              : null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = ref.watch(currentUserProvider);
+    if (_dismissed ||
+        user == null ||
+        user.emailVerified ||
+        !user.hasPassword) {
+      return const SizedBox.shrink();
+    }
+
+    // The home Scaffold has no AppBar, so keep clear of the status bar.
+    return SafeArea(
+      bottom: false,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.fromLTRB(16, 10, 8, 10),
+        decoration: BoxDecoration(
+          color: Colors.amber.shade100,
+          border: Border(
+            bottom: BorderSide(color: Colors.amber.shade300, width: 1),
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.mark_email_unread_outlined,
+                  size: 18,
+                  color: Colors.amber.shade900,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Confirm your email to secure your account.',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.amber.shade900,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close, size: 18),
+                  color: Colors.amber.shade900,
+                  tooltip: 'Dismiss',
+                  visualDensity: VisualDensity.compact,
+                  onPressed: () => setState(() => _dismissed = true),
+                ),
+              ],
+            ),
+            if (_message != null)
+              Padding(
+                padding: const EdgeInsets.only(left: 26, right: 8, top: 2),
+                child: Text(
+                  _message!,
+                  style: TextStyle(fontSize: 12, color: Colors.amber.shade900),
+                ),
+              ),
+            Padding(
+              padding: const EdgeInsets.only(left: 18),
+              child: Row(
+                children: [
+                  TextButton(
+                    onPressed: _busy ? null : _resend,
+                    child: const Text('Resend email'),
+                  ),
+                  TextButton(
+                    onPressed: _busy ? null : _refresh,
+                    child: const Text("I've confirmed"),
+                  ),
+                  if (_busy)
+                    const SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/rythmrun_frontend_flutter/test/core/services/sync_coordinator_test.dart
+++ b/rythmrun_frontend_flutter/test/core/services/sync_coordinator_test.dart
@@ -153,6 +153,12 @@ class _FakeActivityImageRepository implements ActivityImageRepository {
 }
 
 class _MutableAuthRepository implements AuthRepository {
+  @override
+  Future<UserEntity> refreshCurrentUser() => throw UnimplementedError();
+
+  @override
+  Future<void> resendVerificationEmail() => throw UnimplementedError();
+
   int? currentUserId;
 
   _MutableAuthRepository(this.currentUserId);

--- a/rythmrun_frontend_flutter/test/data/repositories/activity_image_repository_impl_test.dart
+++ b/rythmrun_frontend_flutter/test/data/repositories/activity_image_repository_impl_test.dart
@@ -1515,6 +1515,12 @@ class FakeWorkoutLocalDataSource implements WorkoutLocalDataSource {
 }
 
 class FakeAuthRepository implements AuthRepository {
+  @override
+  Future<UserEntity> refreshCurrentUser() => throw UnimplementedError();
+
+  @override
+  Future<void> resendVerificationEmail() => throw UnimplementedError();
+
   UserEntity? currentUser;
   Object? refreshError;
   void Function()? onRefresh;

--- a/rythmrun_frontend_flutter/test/data/repositories/avatar_repository_impl_test.dart
+++ b/rythmrun_frontend_flutter/test/data/repositories/avatar_repository_impl_test.dart
@@ -260,6 +260,12 @@ class _FakeAvatarRemoteDataSource implements AvatarRemoteDataSource {
 
 class _FakeAuthRepository implements AuthRepository {
   @override
+  Future<UserEntity> refreshCurrentUser() => throw UnimplementedError();
+
+  @override
+  Future<void> resendVerificationEmail() => throw UnimplementedError();
+
+  @override
   Future<UserEntity?> getCurrentUser() async => const UserEntity(
     id: '7',
     firstName: 'Test',

--- a/rythmrun_frontend_flutter/test/data/repositories/workout_repository_impl_gate_test.dart
+++ b/rythmrun_frontend_flutter/test/data/repositories/workout_repository_impl_gate_test.dart
@@ -602,6 +602,12 @@ class _BlockingActivityRemoteDataSource implements ActivityRemoteDataSource {
 }
 
 class _FakeAuthRepository implements AuthRepository {
+  @override
+  Future<UserEntity> refreshCurrentUser() => throw UnimplementedError();
+
+  @override
+  Future<void> resendVerificationEmail() => throw UnimplementedError();
+
   int? currentUserId;
 
   _FakeAuthRepository(this.currentUserId);

--- a/rythmrun_frontend_flutter/test/presentation/common/providers/session_provider_test.dart
+++ b/rythmrun_frontend_flutter/test/presentation/common/providers/session_provider_test.dart
@@ -452,6 +452,73 @@ void main() {
       expect(events, <String>['clear']);
     });
 
+    test('refreshing verification state commits a newly verified email', () async {
+      final events = <String>[];
+      final repository = _FakeAuthRepository(events: events);
+      final teardown = _FakeUserScopeTeardown(events: events);
+      final notifier = SessionNotifier(repository, teardown);
+      addTearDown(notifier.dispose);
+
+      await _flushAsyncWork();
+      final admission = notifier.beginAuthenticationAttempt();
+      expect(
+        notifier.completeAuthenticationAttempt(
+          userA.copyWith(emailVerified: false),
+          admission!,
+        ),
+        isTrue,
+      );
+      expect(notifier.state.user?.emailVerified, isFalse);
+
+      repository.serverUser = userA.copyWith(emailVerified: true);
+      await notifier.refreshVerificationState();
+
+      // Both the visible session and the cached copy are committed.
+      expect(notifier.state.user?.emailVerified, isTrue);
+      expect(repository.currentUser?.emailVerified, isTrue);
+    });
+
+    test('a failed verification refresh leaves session state untouched', () async {
+      final events = <String>[];
+      final repository = _FakeAuthRepository(events: events);
+      final teardown = _FakeUserScopeTeardown(events: events);
+      final notifier = SessionNotifier(repository, teardown);
+      addTearDown(notifier.dispose);
+
+      await _flushAsyncWork();
+      final admission = notifier.beginAuthenticationAttempt();
+      notifier.completeAuthenticationAttempt(
+        userA.copyWith(emailVerified: false),
+        admission!,
+      );
+
+      repository.refreshCurrentUserError = StateError('offline');
+      await notifier.refreshVerificationState();
+
+      expect(notifier.state.user?.emailVerified, isFalse);
+    });
+
+    test('a verification refresh for another account is discarded', () async {
+      final events = <String>[];
+      final repository = _FakeAuthRepository(events: events);
+      final teardown = _FakeUserScopeTeardown(events: events);
+      final notifier = SessionNotifier(repository, teardown);
+      addTearDown(notifier.dispose);
+
+      await _flushAsyncWork();
+      final admission = notifier.beginAuthenticationAttempt();
+      notifier.completeAuthenticationAttempt(
+        userA.copyWith(emailVerified: false),
+        admission!,
+      );
+
+      // A response owned by a different account must never be applied.
+      repository.serverUser = userB.copyWith(emailVerified: true);
+      await notifier.refreshVerificationState();
+
+      expect(notifier.state.user?.emailVerified, isFalse);
+    });
+
     test(
       'authentication admission opens only after startup is unauthenticated',
       () async {
@@ -857,6 +924,27 @@ Future<void> _flushAsyncWork() async {
 }
 
 class _FakeAuthRepository implements AuthRepository {
+  /// Server-side user returned by [refreshCurrentUser]; set per test.
+  UserEntity? serverUser;
+  Object? refreshCurrentUserError;
+  int resendCalls = 0;
+
+  @override
+  Future<UserEntity> refreshCurrentUser() async {
+    final error = refreshCurrentUserError;
+    if (error != null) throw error;
+    final user = serverUser;
+    if (user == null) {
+      throw StateError('no server user configured for this test');
+    }
+    return user;
+  }
+
+  @override
+  Future<void> resendVerificationEmail() async {
+    resendCalls += 1;
+  }
+
   final List<String> events;
   final bool failRemoteLogout;
   bool failLocalClear;

--- a/rythmrun_frontend_flutter/test/presentation/features/home/email_verification_banner_test.dart
+++ b/rythmrun_frontend_flutter/test/presentation/features/home/email_verification_banner_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rythmrun_frontend_flutter/domain/entities/user_entity.dart';
+import 'package:rythmrun_frontend_flutter/presentation/common/providers/session_provider.dart';
+import 'package:rythmrun_frontend_flutter/presentation/features/home/widgets/email_verification_banner.dart';
+
+const _base = UserEntity(
+  id: '7',
+  firstName: 'Ada',
+  lastName: 'Runner',
+  email: 'runner@example.test',
+);
+
+Future<void> _pump(WidgetTester tester, UserEntity? user) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: [currentUserProvider.overrideWithValue(user)],
+      child: const MaterialApp(
+        home: Scaffold(body: EmailVerificationBanner()),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('prompts a password account that has not confirmed its email', (
+    tester,
+  ) async {
+    await _pump(tester, _base.copyWith(emailVerified: false));
+
+    expect(find.textContaining('Confirm your email'), findsOneWidget);
+    expect(find.text('Resend email'), findsOneWidget);
+  });
+
+  testWidgets('stays hidden once the email is confirmed', (tester) async {
+    await _pump(tester, _base.copyWith(emailVerified: true));
+
+    expect(find.textContaining('Confirm your email'), findsNothing);
+  });
+
+  testWidgets('never prompts a Google-only account', (tester) async {
+    // Google already proved the address, and the account has no password
+    // flow to fall back on, so the prompt would be wrong and unactionable.
+    await _pump(
+      tester,
+      _base.copyWith(emailVerified: false, hasPassword: false),
+    );
+
+    expect(find.textContaining('Confirm your email'), findsNothing);
+  });
+
+  testWidgets('stays hidden when signed out', (tester) async {
+    await _pump(tester, null);
+
+    expect(find.textContaining('Confirm your email'), findsNothing);
+  });
+
+  testWidgets('can be dismissed for the session', (tester) async {
+    await _pump(tester, _base.copyWith(emailVerified: false));
+    expect(find.textContaining('Confirm your email'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Dismiss'));
+    await tester.pump();
+
+    expect(find.textContaining('Confirm your email'), findsNothing);
+  });
+}

--- a/rythmrun_frontend_flutter/test/presentation/features/profile/profile_view_model_test.dart
+++ b/rythmrun_frontend_flutter/test/presentation/features/profile/profile_view_model_test.dart
@@ -166,6 +166,12 @@ class _FakeAvatarRepository implements AvatarRepository {
 }
 
 class _FakeAuthRepository implements AuthRepository {
+  @override
+  Future<UserEntity> refreshCurrentUser() => throw UnimplementedError();
+
+  @override
+  Future<void> resendVerificationEmail() => throw UnimplementedError();
+
   _FakeAuthRepository({this.result, this.error, this.onRequest});
 
   final UserEntity? result;

--- a/rythmrun_frontend_flutter/test/presentation/navigation/session_navigation_test.dart
+++ b/rythmrun_frontend_flutter/test/presentation/navigation/session_navigation_test.dart
@@ -459,6 +459,12 @@ class _TestSessionNotifier extends SessionNotifier {
 }
 
 class _SuccessfulAuthRepository implements AuthRepository {
+  @override
+  Future<UserEntity> refreshCurrentUser() => throw UnimplementedError();
+
+  @override
+  Future<void> resendVerificationEmail() => throw UnimplementedError();
+
   static const user = UserEntity(
     id: '7',
     firstName: 'A',
@@ -485,6 +491,12 @@ class _NoopGoogleIdentityService implements GoogleIdentityService {
 }
 
 class _UnavailableUnverifiedAuthRepository implements AuthRepository {
+  @override
+  Future<UserEntity> refreshCurrentUser() => throw UnimplementedError();
+
+  @override
+  Future<void> resendVerificationEmail() => throw UnimplementedError();
+
   @override
   Future<bool> hasPendingAuthCleanup() async => false;
 

--- a/rythmrun_frontend_flutter/test/presentation/state/login_nullable_state_transition_test.dart
+++ b/rythmrun_frontend_flutter/test/presentation/state/login_nullable_state_transition_test.dart
@@ -203,6 +203,12 @@ void main() {
 }
 
 class _FakeLoginRepository implements AuthRepository {
+  @override
+  Future<UserEntity> refreshCurrentUser() => throw UnimplementedError();
+
+  @override
+  Future<void> resendVerificationEmail() => throw UnimplementedError();
+
   _FakeLoginRepository({
     required this.failuresRemaining,
     this.googleFailure,

--- a/rythmrun_frontend_flutter/test/presentation/state/nullable_state_transition_test.dart
+++ b/rythmrun_frontend_flutter/test/presentation/state/nullable_state_transition_test.dart
@@ -216,6 +216,12 @@ void main() {
 }
 
 class _FakeAuthRepository implements AuthRepository {
+  @override
+  Future<UserEntity> refreshCurrentUser() => throw UnimplementedError();
+
+  @override
+  Future<void> resendVerificationEmail() => throw UnimplementedError();
+
   _FakeAuthRepository({
     this.registrationFailuresRemaining = 0,
     this.passwordFailuresRemaining = 0,


### PR DESCRIPTION
Adds the client-side verification prompt and the refresh path that lets it clear.

- AuthRepository gains refreshCurrentUser() and resendVerificationEmail(), both routed through the authenticated request coordinator (idempotent replay; resend is guarded as an online-only action).
- SessionNotifier.refreshVerificationState() merges ONLY the emailVerified flag onto the latest session user, mirroring applyProfileUpdate's owner guard and re-merge so a concurrent profile or avatar commit is not clobbered, then persists and publishes it. A failed refresh is swallowed and leaves the session untouched.
- EmailVerificationBanner sits above the tab stack so it is visible from all four tabs. It is shown ONLY to password accounts: a Google-origin account is already verified by Google, so prompting it would be wrong and unactionable. Offers resend (surfacing the server cooldown via ErrorHandler), an "I've confirmed" refresh, and a session dismiss.
- Updated the nine fake AuthRepository implementations for the new members.