### PR TITLE
feat(privacy): make activities private by default and disable social …

### DIFF
--- a/RythmRun_backend_nodejs/README.md
+++ b/RythmRun_backend_nodejs/README.md
@@ -24,7 +24,7 @@ Registration, login, refresh, and liveness are public HTTP routes. Refresh authe
 - Avatars: `POST /api/avatar/upload-url` and `POST /api/avatar/confirm`.
 - Activities: `GET/POST /api/activities` and `GET/PATCH/DELETE /api/activities/:activityId`.
 - Activity images: list, request upload, confirm, and delete below `/api/activities/:activityId/images`.
-- Friends, comments, and likes are exposed below `/api/friends`, `/api/activities/:activityId/comments`, and `/api/activities/:activityId/likes`.
+- Social (friends, comments, likes) is **not exposed**: the routers exist under `src/routes` but are intentionally unmounted (IP-2.5 / D-007) and return `404` until the privacy, visibility, and moderation model is complete.
 - Liveness: `GET /health`.
 
 The route source under `src/routes` is authoritative. In particular, activity updates use `PATCH`; the retired local profile-picture upload route is not part of this API.

--- a/RythmRun_backend_nodejs/prisma/migrations/20260721120000_activities_private_by_default/migration.sql
+++ b/RythmRun_backend_nodejs/prisma/migrations/20260721120000_activities_private_by_default/migration.sql
@@ -1,0 +1,10 @@
+-- IP-2.5: activities are private by default.
+--
+-- The column default flips from true to false. Existing rows created under the
+-- old default-public schema are backfilled to private: the previous default is
+-- not evidence of a user's consent to publish an exact route, so every
+-- currently-public row is made private. This is one-way safe — a rollback
+-- keeps activities private (the audit's public default is never restored).
+ALTER TABLE "Activity" ALTER COLUMN "isPublic" SET DEFAULT false;
+
+UPDATE "Activity" SET "isPublic" = false WHERE "isPublic" = true;

--- a/RythmRun_backend_nodejs/prisma/schema.prisma
+++ b/RythmRun_backend_nodejs/prisma/schema.prisma
@@ -65,7 +65,7 @@ model Activity {
   maxSpeed       Float
   calories       Int?
   description    String?
-  isPublic       Boolean         @default(true)
+  isPublic       Boolean         @default(false)
   pausedDuration Int?
   name           String?
   elevationGain  Float?

--- a/RythmRun_backend_nodejs/src/__tests__/activity.service.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/activity.service.test.ts
@@ -181,6 +181,22 @@ describe('ActivityService', () => {
   });
 
   describe('createActivity', () => {
+    it('forces isPublic to false even when the client requests public (IP-2.5)', async () => {
+      mockTx.activity.findUnique.mockResolvedValueOnce(null);
+      mockTx.activity.create.mockResolvedValue({ id: 1 });
+      mockTx.location.createMany.mockResolvedValue({ count: 1 });
+      mockTx.statusChange.createMany.mockResolvedValue({ count: 4 });
+      mockTx.activity.findUnique.mockResolvedValue(mockActivityReturn);
+
+      await service.createActivity(userId, {
+        ...fullActivityDto,
+        isPublic: true,
+      });
+
+      const createData = mockTx.activity.create.mock.calls[0][0].data;
+      expect(createData.isPublic).toBe(false);
+    });
+
     it('should create activity with all new sync fields', async () => {
       mockTx.activity.findUnique.mockResolvedValueOnce(null);
       mockTx.activity.create.mockResolvedValue({ id: 1 });
@@ -472,6 +488,29 @@ describe('ActivityService', () => {
       expect(result.elevationGain).toBe(45.5);
       expect(result.elevationLoss).toBe(30.2);
       expect(result.metricsVersion).toBe(LEGACY_METRICS_VERSION);
+    });
+
+    it('scopes the lookup to the owner and never matches on public visibility (IP-2.5)', async () => {
+      prisma.activity.findFirst.mockResolvedValue(mockActivityReturn);
+
+      await service.getActivityById(userId, 1);
+
+      const findFirstArgs = prisma.activity.findFirst.mock.calls[0][0];
+      expect(findFirstArgs.where).toEqual({ id: 1, userId });
+      expect(findFirstArgs.where.OR).toBeUndefined();
+      expect(JSON.stringify(findFirstArgs.where)).not.toContain('isPublic');
+    });
+
+    it('denies a non-owner: an activity owned by another user is not found', async () => {
+      // With an owner-scoped where, Prisma returns null for a foreign activity.
+      prisma.activity.findFirst.mockResolvedValue(null);
+
+      await expect(service.getActivityById(userId, 999)).rejects.toThrow(
+        /not found or access denied/i,
+      );
+
+      const findFirstArgs = prisma.activity.findFirst.mock.calls[0][0];
+      expect(findFirstArgs.where).toEqual({ id: 999, userId });
     });
   });
 

--- a/RythmRun_backend_nodejs/src/__tests__/http-security-boundary.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/http-security-boundary.test.ts
@@ -383,6 +383,22 @@ describe('HTTP security boundaries', () => {
   });
 
   it.each([
+    ['GET', '/api/friends'],
+    ['POST', '/api/friends/requests'],
+    ['GET', '/api/activities/1/comments'],
+    ['POST', '/api/activities/1/comments'],
+    ['POST', '/api/activities/1/likes'],
+    ['DELETE', '/api/activities/1/likes'],
+  ])(
+    'keeps the disabled social %s %s endpoint unavailable (IP-2.5)',
+    async (method, path) => {
+      const response = await requestJson(server, method, path);
+
+      expect(response.statusCode).toBe(404);
+    },
+  );
+
+  it.each([
     [
       '/api/avatar/upload-url',
       'requestUpload',

--- a/RythmRun_backend_nodejs/src/app.ts
+++ b/RythmRun_backend_nodejs/src/app.ts
@@ -47,12 +47,16 @@ export function createApp(routes: ApplicationRoutes) {
   });
 
   app.use('/api/users', routes.users);
-  app.use('/api/friends', routes.friends);
   app.use('/api/avatar', routes.avatar);
   app.use('/api/activities/:activityId/images', routes.activityImages);
   app.use('/api/activities', routes.activities);
-  app.use('/api/activities/:activityId/comments', routes.comments);
-  app.use('/api/activities/:activityId/likes', routes.likes);
+
+  // IP-2.5 / D-007: the friend, comment, and like routers are intentionally
+  // NOT mounted. Social features stay disabled (requests fall through to 404)
+  // until authentication, privacy, route visibility, moderation, and
+  // blocking/reporting exist. The routers/services remain in the tree
+  // (`routes.friends`, `routes.comments`, `routes.likes`) for future re-enable;
+  // do not remount them merely to expose an unsupported product journey.
 
   app.get('/health', (_req: Request, res: Response) => {
     res.json({ status: 'ok', timestamp: new Date().toISOString() });

--- a/RythmRun_backend_nodejs/src/services/activity.service.ts
+++ b/RythmRun_backend_nodejs/src/services/activity.service.ts
@@ -121,7 +121,10 @@ export class ActivityService {
                     maxSpeed: dto.maxSpeed,
                     calories: dto.calories,
                     description: dto.description,
-                    isPublic: dto.isPublic ?? true,
+                    // IP-2.5: activities are private until a route-redaction /
+                    // public-sharing model exists. The client-supplied value is
+                    // deliberately ignored so nothing can be created public.
+                    isPublic: false,
                     pausedDuration: dto.pausedDuration,
                     name: dto.name,
                     elevationGain: dto.elevationGain,
@@ -316,7 +319,9 @@ export class ActivityService {
                     ...(dto.description !== undefined && {
                         description: dto.description
                     }),
-                    ...(dto.isPublic !== undefined && { isPublic: dto.isPublic }),
+                    // IP-2.5: visibility is not client-editable while public
+                    // sharing is disabled; an update can never turn a private
+                    // activity public.
                     ...(dto.pausedDuration !== undefined && {
                         pausedDuration: dto.pausedDuration
                     }),
@@ -434,14 +439,13 @@ export class ActivityService {
     }
 
     async getActivityById(userId: number, activityId: number) {
-        // Find activity and check if it belongs to user or is public
+        // IP-2.5: exact routes are owner-only. A request for an activity the
+        // caller does not own resolves to the same not-found path as a missing
+        // id, so another user's route/images/identity are never returned.
         const activity = await this.prisma.activity.findFirst({
             where: {
                 id: activityId,
-                OR: [
-                    { userId },        // User's own activity
-                    { isPublic: true } // Public activity
-                ]
+                userId
             },
             include: {
                 ...this.activityInclude,

--- a/RythmRun_backend_nodejs/src/utils/seedData.ts
+++ b/RythmRun_backend_nodejs/src/utils/seedData.ts
@@ -54,7 +54,7 @@ async function main() {
       maxSpeed: 2.78, // 10km/h
       calories: 500,
       description: 'Morning run in the park',
-      isPublic: true,
+      isPublic: false, // IP-2.5: activities are private by default
       locations: {
         create: [
           {


### PR DESCRIPTION
…paths

IP-2.5 route privacy (repository-delivered; migration applies via staging).

- Activities default isPublic=false; a forward migration flips the column default and backfills every existing row to private (the old default is not consent). One-way safe: rollback keeps activities private.
- createActivity forces isPublic=false and updateActivity can no longer change visibility, so nothing can be created or turned public while route redaction and a public-sharing model do not exist.
- getActivityById is owner-only: a request for an activity the caller does not own resolves to not-found, so another user's route points, signed image URLs, and identity are never returned. (List, update, delete, and the activity-image routes were already owner-scoped.)
- Unmount the friend/comment/like routers (D-007): social stays disabled (404) until privacy, visibility, moderation, and blocking/reporting exist. The routers/services remain in the tree for future re-enable.
- Backend README no longer advertises the social endpoints; seed data made private.
- Tests: create-forces-private, owner-only lookup, non-owner denial, and social endpoints return 404.

290 backend tests pass (9 new); typecheck, build, and built-ESM smoke pass.