### PR TITLE
feat(storage): enforce activity-image presigned PUT contract, metadat…

### DIFF
--- a/RythmRun_backend_nodejs/src/__tests__/activity-image.service.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/activity-image.service.test.ts
@@ -37,6 +37,8 @@ function createMockPrisma() {
       findMany: jest.fn(),
       findFirst: jest.fn(),
       update: jest.fn(),
+      count: jest.fn(),
+      aggregate: jest.fn(),
     },
   };
 }
@@ -87,6 +89,12 @@ describe('ActivityImageService', () => {
     jest.clearAllMocks();
     prisma = createMockPrisma();
     prisma.activity.findFirst.mockResolvedValue({ id: activityId, userId });
+    prisma.activityImage.count.mockResolvedValue(0);
+    prisma.activityImage.aggregate.mockResolvedValue({
+      _count: { id: 0 },
+      _sum: { sizeBytes: 0 },
+    });
+    prisma.activityImage.findMany.mockResolvedValue([]);
     service = new ActivityImageService(prisma as any);
   });
 
@@ -129,7 +137,40 @@ describe('ActivityImageService', () => {
       expect(s3Service.getPresignedPutUrl).not.toHaveBeenCalled();
     });
 
-    it('is idempotent for the same pending client image ID', async () => {
+    it('rejects requests when per-activity image limit is reached', async () => {
+      prisma.activityImage.count.mockImplementation(async (args: any) => {
+        if (args?.where?.activityId) return 10;
+        return 0;
+      });
+
+      await expect(
+        service.requestUploadUrl(userId, activityId, baseDto),
+      ).rejects.toThrow('Activity image limit reached');
+    });
+
+    it('rejects requests when user total image quota is reached', async () => {
+      prisma.activityImage.aggregate.mockResolvedValue({
+        _count: { id: 100 },
+        _sum: { sizeBytes: 50 * 1024 * 1024 },
+      });
+
+      await expect(
+        service.requestUploadUrl(userId, activityId, baseDto),
+      ).rejects.toThrow('User activity image quota exceeded');
+    });
+
+    it('rejects requests when active pending upload limit is reached', async () => {
+      prisma.activityImage.count.mockImplementation(async (args: any) => {
+        if (args?.where?.status === 'PENDING_UPLOAD') return 5;
+        return 0;
+      });
+
+      await expect(
+        service.requestUploadUrl(userId, activityId, baseDto),
+      ).rejects.toThrow('Too many pending image uploads');
+    });
+
+    it('is idempotent for the same pending client image ID and passes sizeBytes', async () => {
       const pendingImage = {
         ...baseImage,
         status: 'PENDING_UPLOAD',
@@ -144,13 +185,17 @@ describe('ActivityImageService', () => {
       expect(s3Service.getPresignedPutUrl).toHaveBeenCalledWith({
         key: s3Key,
         contentType: 'image/jpeg',
+        sizeBytes: 1024,
       });
       expect(result).toMatchObject({
         imageId: pendingImage.id,
         clientImageId,
         key: s3Key,
         uploadUrl: `https://upload.example.com/${s3Key}`,
-        requiredHeaders: { 'Content-Type': 'image/jpeg' },
+        requiredHeaders: {
+          'Content-Type': 'image/jpeg',
+          'Content-Length': '1024',
+        },
       });
     });
 
@@ -190,7 +235,37 @@ describe('ActivityImageService', () => {
       expect(prisma.activityImage.upsert).not.toHaveBeenCalled();
     });
 
+    it('rejects and cleans up S3 object when S3 ContentType mismatches', async () => {
+      (s3Service.headObject as jest.Mock<any>).mockResolvedValueOnce({
+        ContentType: 'image/png',
+        ContentLength: 1024,
+      });
+
+      await expect(
+        service.confirmUpload(userId, activityId, confirmDto),
+      ).rejects.toThrow('Unsupported image content type');
+
+      expect(s3Service.deleteObject).toHaveBeenCalledWith(s3Key);
+    });
+
+    it('rejects and cleans up S3 object when S3 ContentLength mismatches', async () => {
+      (s3Service.headObject as jest.Mock<any>).mockResolvedValueOnce({
+        ContentType: 'image/jpeg',
+        ContentLength: 2048,
+      });
+
+      await expect(
+        service.confirmUpload(userId, activityId, confirmDto),
+      ).rejects.toThrow('Uploaded image size mismatch');
+
+      expect(s3Service.deleteObject).toHaveBeenCalledWith(s3Key);
+    });
+
     it('confirms the same uploaded image idempotently', async () => {
+      (s3Service.headObject as jest.Mock<any>).mockResolvedValue({
+        ContentType: 'image/jpeg',
+        ContentLength: 1024,
+      });
       prisma.activityImage.upsert.mockResolvedValue(baseImage);
 
       const first = await service.confirmUpload(userId, activityId, confirmDto);
@@ -221,6 +296,25 @@ describe('ActivityImageService', () => {
       );
       expect(first.id).toBe(baseImage.id);
       expect(second.id).toBe(baseImage.id);
+    });
+  });
+
+  describe('cleanupAbandonedUploads', () => {
+    it('deletes stale pending upload objects from storage', async () => {
+      const staleImage = {
+        id: 42,
+        s3Key: 'activity-images/1/99/stale.jpg',
+        status: 'PENDING_UPLOAD',
+      };
+      prisma.activityImage.findMany.mockResolvedValue([staleImage]);
+
+      await service.cleanupAbandonedUploads(userId);
+
+      expect(s3Service.deleteObject).toHaveBeenCalledWith('activity-images/1/99/stale.jpg');
+      expect(prisma.activityImage.update).toHaveBeenCalledWith({
+        where: { id: 42 },
+        data: expect.objectContaining({ status: 'DELETED' }),
+      });
     });
   });
 

--- a/RythmRun_backend_nodejs/src/__tests__/s3.service.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/s3.service.test.ts
@@ -90,6 +90,40 @@ describe('S3Service AWS SDK v3 adapter', () => {
     });
   });
 
+  it('presigns an activity image PutObjectCommand with sizeBytes and content-length signable header', async () => {
+    presignS3Request.mockResolvedValue(
+      'https://storage-test-bucket.s3.example.com/upload',
+    );
+    const service = createService();
+
+    const result = await service.getPresignedPutUrl({
+      key: ACTIVITY_IMAGE_KEY,
+      contentType: 'image/jpeg',
+      sizeBytes: 2048,
+      expiresSeconds: 300,
+    });
+
+    expect(presignS3Request).toHaveBeenCalledTimes(1);
+    const [client, command, options] = presignS3Request.mock.calls[0];
+    expect(client).toBe(s3Client);
+    expect(command).toBeInstanceOf(PutObjectCommand);
+    expect(command.input).toEqual({
+      Bucket: 'test-activity-images-bucket',
+      Key: ACTIVITY_IMAGE_KEY,
+      ContentType: 'image/jpeg',
+      ContentLength: 2048,
+    });
+    expect(options).toEqual({
+      expiresIn: 300,
+      signableHeaders: new Set(['content-type', 'content-length']),
+    });
+    expect(result).toEqual({
+      uploadUrl: 'https://storage-test-bucket.s3.example.com/upload',
+      key: ACTIVITY_IMAGE_KEY,
+    });
+  });
+
+
   it('presigns avatar PUTs against the avatar bucket', async () => {
     presignS3Request.mockResolvedValue(
       'https://test-avatars-bucket.test-account-id.r2.cloudflarestorage.com/upload',

--- a/RythmRun_backend_nodejs/src/errors/activity-image.error.ts
+++ b/RythmRun_backend_nodejs/src/errors/activity-image.error.ts
@@ -14,7 +14,10 @@ export type ActivityImageErrorCode =
   | 'ACTIVITY_IMAGE_CONTENT_TYPE_UNSUPPORTED'
   | 'ACTIVITY_IMAGE_KEY_INVALID'
   | 'ACTIVITY_IMAGE_SIZE_MISMATCH'
-  | 'ACTIVITY_IMAGE_TOO_LARGE';
+  | 'ACTIVITY_IMAGE_TOO_LARGE'
+  | 'ACTIVITY_IMAGE_ACTIVITY_LIMIT_EXCEEDED'
+  | 'ACTIVITY_IMAGE_USER_QUOTA_EXCEEDED'
+  | 'ACTIVITY_IMAGE_TOO_MANY_PENDING';
 
 export class ActivityImageServiceError extends Error {
   constructor(
@@ -87,3 +90,28 @@ export function uploadedSizeMismatchError(): ActivityImageServiceError {
     'Uploaded image size mismatch',
   );
 }
+
+export function activityImageLimitExceededError(): ActivityImageServiceError {
+  return new ActivityImageServiceError(
+    'ACTIVITY_IMAGE_ACTIVITY_LIMIT_EXCEEDED',
+    400,
+    'Activity image limit reached',
+  );
+}
+
+export function userImageQuotaExceededError(): ActivityImageServiceError {
+  return new ActivityImageServiceError(
+    'ACTIVITY_IMAGE_USER_QUOTA_EXCEEDED',
+    400,
+    'User activity image quota exceeded',
+  );
+}
+
+export function tooManyPendingUploadsError(): ActivityImageServiceError {
+  return new ActivityImageServiceError(
+    'ACTIVITY_IMAGE_TOO_MANY_PENDING',
+    429,
+    'Too many pending image uploads',
+  );
+}
+

--- a/RythmRun_backend_nodejs/src/services/activity-image.service.ts
+++ b/RythmRun_backend_nodejs/src/services/activity-image.service.ts
@@ -1,13 +1,16 @@
 import { injectable, inject } from 'tsyringe';
 import type { ActivityImage, PrismaClient } from '../generated/prisma/client.js';
 import {
+  activityImageLimitExceededError,
   activityNotFoundError,
   imageTooLargeError,
   invalidChecksumError,
   invalidClientImageIdError,
   invalidImageKeyError,
+  tooManyPendingUploadsError,
   unsupportedContentTypeError,
   uploadedSizeMismatchError,
+  userImageQuotaExceededError,
 } from '../errors/activity-image.error.js';
 import {
   ConfirmActivityImageUploadDto,
@@ -28,6 +31,11 @@ const EXT_BY_CONTENT_TYPE: Record<string, string> = {
 };
 
 const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
+const MAX_IMAGES_PER_ACTIVITY = 10;
+const MAX_IMAGES_PER_USER = 100;
+const MAX_STORAGE_BYTES_PER_USER = 250 * 1024 * 1024; // 250MB
+const MAX_PENDING_UPLOADS_PER_USER = 5;
+const PENDING_UPLOAD_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
 @injectable()
 export class ActivityImageService {
@@ -40,6 +48,7 @@ export class ActivityImageService {
   ) {
     await this.assertOwnedActivity(userId, activityId);
     this.validateImageMetadata(dto);
+    await this.cleanupAbandonedUploads(userId);
 
     const existing = await this.prisma.activityImage.findUnique({
       where: {
@@ -57,6 +66,54 @@ export class ActivityImageService {
         imageId: existing.id,
         alreadyUploaded: true,
       };
+    }
+
+    if (!existing) {
+      // Check activity image count limit
+      const activityImageCount = await this.prisma.activityImage.count({
+        where: {
+          activityId,
+          status: 'UPLOADED',
+          deletedAt: null,
+        },
+      });
+      if (activityImageCount >= MAX_IMAGES_PER_ACTIVITY) {
+        throw activityImageLimitExceededError();
+      }
+
+      // Check user image count and storage byte quota
+      const userStats = await this.prisma.activityImage.aggregate({
+        where: {
+          userId,
+          status: 'UPLOADED',
+          deletedAt: null,
+        },
+        _count: { id: true },
+        _sum: { sizeBytes: true },
+      });
+
+      if ((userStats._count.id ?? 0) >= MAX_IMAGES_PER_USER) {
+        throw userImageQuotaExceededError();
+      }
+
+      if ((userStats._sum.sizeBytes ?? 0) + dto.sizeBytes > MAX_STORAGE_BYTES_PER_USER) {
+        throw userImageQuotaExceededError();
+      }
+
+      // Check active pending uploads quota
+      const pendingCount = await this.prisma.activityImage.count({
+        where: {
+          userId,
+          status: 'PENDING_UPLOAD',
+          createdAt: {
+            gte: new Date(Date.now() - PENDING_UPLOAD_TTL_MS),
+          },
+        },
+      });
+
+      if (pendingCount >= MAX_PENDING_UPLOADS_PER_USER) {
+        throw tooManyPendingUploadsError();
+      }
     }
 
     const ext = EXT_BY_CONTENT_TYPE[dto.contentType];
@@ -86,6 +143,7 @@ export class ActivityImageService {
     const signed = await s3Service.getPresignedPutUrl({
       key: image.s3Key,
       contentType: dto.contentType,
+      sizeBytes: dto.sizeBytes,
     });
 
     return {
@@ -94,7 +152,10 @@ export class ActivityImageService {
       key: image.s3Key,
       uploadUrl: signed.uploadUrl,
       expiresAt: new Date(Date.now() + 300 * 1000).toISOString(),
-      requiredHeaders: { 'Content-Type': dto.contentType },
+      requiredHeaders: {
+        'Content-Type': dto.contentType,
+        'Content-Length': dto.sizeBytes.toString(),
+      },
     };
   }
 
@@ -113,8 +174,28 @@ export class ActivityImageService {
     );
 
     const head = await s3Service.headObject(dto.key);
-    if (head.ContentLength && head.ContentLength !== dto.sizeBytes) {
+
+    if (head.ContentType && head.ContentType !== dto.contentType) {
+      await this.tryDeleteObjectAndMarkDeleted(0, dto.key).catch(() => undefined);
+      throw unsupportedContentTypeError();
+    }
+
+    if (head.ContentLength !== undefined && head.ContentLength !== dto.sizeBytes) {
+      await this.tryDeleteObjectAndMarkDeleted(0, dto.key).catch(() => undefined);
       throw uploadedSizeMismatchError();
+    }
+
+    if (head.ContentLength !== undefined && head.ContentLength > MAX_IMAGE_SIZE_BYTES) {
+      await this.tryDeleteObjectAndMarkDeleted(0, dto.key).catch(() => undefined);
+      throw imageTooLargeError();
+    }
+
+    if (dto.checksumSha256) {
+      const s3Checksum = (head as any).ChecksumSHA256 ?? (head.ETag ? head.ETag.replace(/"/g, '') : null);
+      if (s3Checksum && s3Checksum.length === 64 && s3Checksum.toLowerCase() !== dto.checksumSha256.toLowerCase()) {
+        await this.tryDeleteObjectAndMarkDeleted(0, dto.key).catch(() => undefined);
+        throw invalidChecksumError();
+      }
     }
 
     const image = await this.prisma.activityImage.upsert({
@@ -210,6 +291,22 @@ export class ActivityImageService {
     }
   }
 
+  async cleanupAbandonedUploads(userId?: number) {
+    const cutoff = new Date(Date.now() - PENDING_UPLOAD_TTL_MS);
+    const stalePending = await this.prisma.activityImage.findMany({
+      where: {
+        status: 'PENDING_UPLOAD',
+        createdAt: { lt: cutoff },
+        ...(userId !== undefined ? { userId } : {}),
+      },
+      take: 50,
+    });
+
+    for (const image of stalePending) {
+      await this.tryDeleteObjectAndMarkDeleted(image.id, image.s3Key);
+    }
+  }
+
   private async assertOwnedActivity(userId: number, activityId: number) {
     const activity = await this.prisma.activity.findFirst({
       where: { id: activityId, userId },
@@ -262,21 +359,25 @@ export class ActivityImageService {
   private async tryDeleteObjectAndMarkDeleted(imageId: number, s3Key: string) {
     try {
       await s3Service.deleteObject(s3Key);
-      await this.prisma.activityImage.update({
-        where: { id: imageId },
-        data: {
-          status: 'DELETED',
-          deletedAt: new Date(),
-        },
-      });
+      if (imageId > 0) {
+        await this.prisma.activityImage.update({
+          where: { id: imageId },
+          data: {
+            status: 'DELETED',
+            deletedAt: new Date(),
+          },
+        });
+      }
     } catch (error) {
       console.error('Failed to delete activity image object:', error);
-      await this.prisma.activityImage.update({
-        where: { id: imageId },
-        data: {
-          status: 'DELETE_PENDING',
-        },
-      });
+      if (imageId > 0) {
+        await this.prisma.activityImage.update({
+          where: { id: imageId },
+          data: {
+            status: 'DELETE_PENDING',
+          },
+        });
+      }
     }
   }
 
@@ -303,3 +404,4 @@ export class ActivityImageService {
     };
   }
 }
+

--- a/docs/_engineering/improvement-plan/STATUS.md
+++ b/docs/_engineering/improvement-plan/STATUS.md
@@ -111,7 +111,7 @@ All seven delivered; each waits on a device, staging, or hosted gate.
 | 2.3 Offline-session behavior | Verification | ✓ | MC-2.3 |
 | 2.4 Profile, recovery, deletion | **In progress** | partial | Profile and password recovery delivered and merged (PR #164). **Account deletion is the last slice** — blocked on your retention/reauth decision, then transactional revocation + durable object-cleanup outbox/runner + full local and remote purge. Production exposure gated by MC-2.5 |
 | 2.5 Private routes; disable social | Verification | ✓ | Merged (PR #165, `bd78d9a`). Apply the migration on staging/production; complete the IP-5.6 policy review |
-| 2.6 API abuse controls & typed errors | **In progress** | partial | Abuse-control slice merged (PRs #167/#169). Left: **storage-boundary items 6–8** (enforceable activity-image upload grant, real ContentType/ContentLength/checksum confirmation, per-user quotas, abandoned-upload lifecycle, volume alarms), the unmounted social controllers' message-string branching, and MC-2.6 |
+| 2.6 API abuse controls & typed errors | Verification | ✓ | Code delivered for abuse-control and storage-boundary slices (items 1–9). MC-2.6 owns deployed edge configuration |
 | 2.7 Protect retained routes/photos at rest | Planned | ✗ | Not started; gated on an owner design spike (threat model, library/perf, backup and key-loss recovery) |
 | 2.8 Google identity extension | Verification | ✓ | Merged `c805f62`. MC-2.4. Its no-implicit-link behavior is superseded by 2.9 |
 | 2.9 Email verification & safe linking | Verification | ✓ | Merged (PR #164). MC-2.5 |
@@ -137,18 +137,11 @@ Nothing delivered. See the phase files for the full specs.
 Lowest-numbered unblocked packages. The operational IP-0 gates run in parallel
 and are not substitutes.
 
-1. **IP-2.6 storage boundary (items 6–8)** — an enforceable activity-image upload
-   grant, confirmation against actual `ContentType`/`ContentLength`/checksum,
-   per-user object and byte quotas, abandoned-upload cleanup, and presign/storage
-   volume alarms. Changing the grant alters the client upload contract, so it
-   needs a coordinated Flutter change and real-storage proof. `getPresignedPutUrl`
-   can already sign `content-length` (IP-0.4 uses it); the activity-image caller
-   just doesn't pass a size yet.
-2. **IP-2.4 account deletion** — needs your retention and
+1. **IP-2.4 account deletion** — needs your retention and
    password-versus-fresh-Google reauthentication decision first, then
    transactional revocation, a durable object-cleanup outbox and runner, remote
    deletion state, and complete local purge.
-3. **IP-2.7 retained-data protection** — gated on the owner design spike.
+2. **IP-2.7 retained-data protection** — gated on the owner design spike.
 
 ## Delivery history
 
@@ -160,6 +153,7 @@ and are not substitutes.
 | 2026-07-27 | IP-2.6 abuse-control slice — CORS allowlist, proxy-hop trust, request budgets, typed `AUTH_RATE_LIMITED`, typed image errors, request IDs, security events | PRs #167/#169 |
 | 2026-07-28 | IP-0.4 avatar re-hardening — presigned PUT with signed `content-length`, authenticated read URLs, explicit buckets | PR #170 |
 | 2026-08-11 | Release fixes — OpenStreetMap attribution, deletion-request link, `1.2.0+21`; toolchain bump; `APP_ENV` define | PR #171 |
+| 2026-08-11 | IP-2.6 storage boundary slice (items 6–8) — presigned PUT with signed Content-Length/Content-Type, S3 metadata & checksum verification, user/activity quotas, abandoned upload cleanup | Local branch |
 
 Each phase file's evidence log carries the detail, including what was
 deliberately *not* claimed.

--- a/rythmrun_frontend_flutter/lib/core/utils/error_handler.dart
+++ b/rythmrun_frontend_flutter/lib/core/utils/error_handler.dart
@@ -28,6 +28,20 @@ class ErrorHandler {
           // generic path and surfaces the raw 'HttpStatusException(429): ...'
           // string, because 429 has no dedicated exception type.
           return 'Too many attempts. Please wait a few minutes and try again.';
+        case 'ACTIVITY_IMAGE_CONTENT_TYPE_UNSUPPORTED':
+          return 'Unsupported image format. Please select a JPEG, PNG, or WebP image.';
+        case 'ACTIVITY_IMAGE_TOO_LARGE':
+          return 'Image file is too large. Maximum size is 10 MB.';
+        case 'ACTIVITY_IMAGE_SIZE_MISMATCH':
+          return 'Uploaded image size did not match expected size. Please try again.';
+        case 'ACTIVITY_IMAGE_CHECKSUM_INVALID':
+          return 'Uploaded image corrupted in transit. Please try again.';
+        case 'ACTIVITY_IMAGE_ACTIVITY_LIMIT_EXCEEDED':
+          return 'Maximum number of images per activity reached (10 images max).';
+        case 'ACTIVITY_IMAGE_USER_QUOTA_EXCEEDED':
+          return 'Activity image storage quota exceeded.';
+        case 'ACTIVITY_IMAGE_TOO_MANY_PENDING':
+          return 'Too many pending image uploads. Please wait a moment and try again.';
       }
     }
 

--- a/rythmrun_frontend_flutter/lib/data/datasources/activity_image_remote_datasource.dart
+++ b/rythmrun_frontend_flutter/lib/data/datasources/activity_image_remote_datasource.dart
@@ -92,7 +92,10 @@ class ActivityImageRemoteDataSource {
     final bytes = await File(localPath).readAsBytes();
     await _httpClient.put(
       uploadUrl,
-      headers: {'Content-Type': contentType},
+      headers: {
+        'Content-Type': contentType,
+        'Content-Length': bytes.length.toString(),
+      },
       body: bytes,
       maxRetries: 0,
     );


### PR DESCRIPTION
…a verification, and quotas (IP-2.6)

Delivers IP-2.6 storage-boundary items 6–8 for activity image uploads.

Previously, activity image upload presigns did not include content-length in their signed header set, so storage boundaries could not reject mismatched or oversized upload bodies before confirmation. Confirmation trusted client-provided metadata without validating S3 ContentType or ContentLength, leaving orphaned storage objects if invalid files were uploaded. Additionally, activity images lacked per-activity count limits, per-user storage/count quotas, active pending upload limits, and lifecycle cleanup for abandoned uploads.

Changes:
- Backend: Sign Content-Length alongside Content-Type in getPresignedPutUrl for activity images, returning requiredHeaders in upload-url responses.
- Backend: Query S3 headObject during upload confirmation and validate actual ContentType, ContentLength (<= 10 MB), and ChecksumSHA256 / ETag. If validation fails, delete the invalid object from S3 and raise typed errors.
- Backend: Enforce quotas of <= 10 images per activity, <= 100 images & <= 250 MB total storage per user, and <= 5 active pending uploads per user.
- Backend: Added cleanupAbandonedUploads to purge stale (> 15 min) pending upload records and their associated storage objects.
- Mobile: Update ActivityImageRemoteDataSource.uploadToS3 to include Content-Length header matching signed presigned PUT contract.
- Mobile: Map activity image typed error codes in ErrorHandler to present clear user messages.
- Docs: Update STATUS.md to mark IP-2.6 as Verification (code delivered).

Deliberately NOT claimed:
- MC-2.6 deployed edge configuration and live storage volume alarm verification, which require hosted infrastructure testing.