### PR TITLE
feat(auth): make auth timing tunable via env + dart-define (Phase 0 c…

### DIFF
--- a/RythmRun_backend_nodejs/.env.example
+++ b/RythmRun_backend_nodejs/.env.example
@@ -56,6 +56,39 @@ GOOGLE_SERVER_CLIENT_ID="REPLACE_WITH_GOOGLE_SERVER_CLIENT_ID"
 # set 1.
 # TRUST_PROXY_HOPS=0
 
+# Auth timing knobs (OPTIONAL — every default reproduces today's behavior)
+# ----------------------------------------------------------------------------
+# All optional. Leave a variable unset and the default in parentheses applies,
+# exactly as the service behaved before these were tunable. A present value must
+# be an integer inside the stated range or the process refuses to start (typo
+# protection, not policy: ACCESS_TOKEN_TTL_SECONDS=9000000 should fail the boot,
+# not silently mint a three-month token).
+#
+# The point is live testing without a rebuild: set ACCESS_TOKEN_TTL_SECONDS=30
+# on a deployment and the already-installed app starts refreshing every 30s,
+# because the client reads token lifetime straight from the JWT.
+#
+# Variable                              Default              Range
+# ACCESS_TOKEN_TTL_SECONDS              900 (15m)            30 .. 86400
+# REFRESH_SESSION_TTL_SECONDS           604800 (7d)          60 .. 7776000
+# MAX_ACTIVE_SESSIONS_PER_USER          5                    1 .. 100
+# REFRESH_REUSE_GRACE_SECONDS           60 (0 = strict)      0 .. 300   (consumed in Phase 2)
+# EMAIL_VERIFICATION_TTL_SECONDS        86400 (24h)          60 .. 604800
+# EMAIL_VERIFICATION_COOLDOWN_SECONDS   60                   0 .. 3600
+# PASSWORD_RESET_TTL_SECONDS            1800 (30m)           60 .. 86400
+# PASSWORD_RESET_COOLDOWN_SECONDS       60                   0 .. 3600
+# RETRY_SWEEP_INTERVAL_SECONDS          900 (15m)            10 .. 86400
+#
+#ACCESS_TOKEN_TTL_SECONDS=900
+#REFRESH_SESSION_TTL_SECONDS=604800
+#MAX_ACTIVE_SESSIONS_PER_USER=5
+#REFRESH_REUSE_GRACE_SECONDS=60
+#EMAIL_VERIFICATION_TTL_SECONDS=86400
+#EMAIL_VERIFICATION_COOLDOWN_SECONDS=60
+#PASSWORD_RESET_TTL_SECONDS=1800
+#PASSWORD_RESET_COOLDOWN_SECONDS=60
+#RETRY_SWEEP_INTERVAL_SECONDS=900
+
 # Email Verification (OPTIONAL feature group)
 # ----------------------------------------------------------------------------
 # Unlike the variables above, these are NOT fail-closed: leave the whole group

--- a/RythmRun_backend_nodejs/src/__tests__/auth-session.postgres.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/auth-session.postgres.test.ts
@@ -10,6 +10,7 @@ import {
   digestRefreshToken,
 } from '../services/auth-session.service.js';
 import { UserService } from '../services/user.service.js';
+import { DEFAULT_AUTH_TIMING } from '../config/env.js';
 
 const RUN_INTEGRATION = process.env.RUN_DATABASE_INTEGRATION === '1';
 const integrationDescribe = RUN_INTEGRATION ? describe : describe.skip;
@@ -67,10 +68,10 @@ integrationDescribe('auth sessions on PostgreSQL', () => {
     const databaseUrl = requireTestDatabaseUrl();
     databaseA = createDatabase(databaseUrl);
     databaseB = createDatabase(databaseUrl);
-    sessionsA = new AuthSessionService(databaseA.client);
-    sessionsB = new AuthSessionService(databaseB.client);
-    usersA = new UserService(databaseA.client, sessionsA);
-    usersB = new UserService(databaseB.client, sessionsB);
+    sessionsA = new AuthSessionService(databaseA.client, DEFAULT_AUTH_TIMING);
+    sessionsB = new AuthSessionService(databaseB.client, DEFAULT_AUTH_TIMING);
+    usersA = new UserService(databaseA.client, sessionsA, DEFAULT_AUTH_TIMING);
+    usersB = new UserService(databaseB.client, sessionsB, DEFAULT_AUTH_TIMING);
   });
 
   beforeEach(async () => {
@@ -170,9 +171,14 @@ integrationDescribe('auth sessions on PostgreSQL', () => {
       firstname: 'Grace',
       lastname: 'Runner',
     };
-    const googleUsers = new UserService(databaseA.client, sessionsA, {
-      verifyIdToken: async () => googleIdentity,
-    });
+    const googleUsers = new UserService(
+      databaseA.client,
+      sessionsA,
+      DEFAULT_AUTH_TIMING,
+      {
+        verifyIdToken: async () => googleIdentity,
+      },
+    );
 
     const authenticated = await googleUsers.googleLogin({
       idToken: 'test-verifier-token',
@@ -232,6 +238,7 @@ integrationDescribe('auth sessions on PostgreSQL', () => {
     const conflictingGoogleUsers = new UserService(
       databaseA.client,
       sessionsA,
+      DEFAULT_AUTH_TIMING,
       {
         verifyIdToken: async () => ({
           ...googleIdentity,
@@ -366,7 +373,7 @@ integrationDescribe('auth sessions on PostgreSQL', () => {
     const issuanceGate = new Promise<void>((resolve) => {
       releaseIssuance = resolve;
     });
-    const gatedSessions = new AuthSessionService(databaseA.client);
+    const gatedSessions = new AuthSessionService(databaseA.client, DEFAULT_AUTH_TIMING);
     const runTransaction =
       gatedSessions.withSerializableTransaction.bind(gatedSessions);
     gatedSessions.withSerializableTransaction = (async (operation: unknown) => {
@@ -377,6 +384,7 @@ integrationDescribe('auth sessions on PostgreSQL', () => {
     const staleLoginUserService = new UserService(
       databaseA.client,
       gatedSessions,
+      DEFAULT_AUTH_TIMING,
     );
 
     const staleLogin = staleLoginUserService

--- a/RythmRun_backend_nodejs/src/__tests__/auth-session.service.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/auth-session.service.test.ts
@@ -6,12 +6,10 @@ import jwt from 'jsonwebtoken';
 
 import type { User } from '../generated/prisma/client.js';
 import {
-  ACCESS_TOKEN_LIFETIME_SECONDS,
   AuthSessionService,
-  MAX_ACTIVE_SESSIONS_PER_USER,
-  REFRESH_SESSION_LIFETIME_SECONDS,
   digestRefreshToken,
 } from '../services/auth-session.service.js';
+import { DEFAULT_AUTH_TIMING } from '../config/env.js';
 
 const ACCESS_SECRET = 'unit-access-secret-0123456789-abcdefgh';
 const REFRESH_SECRET = 'unit-refresh-secret-0123456789-abcdefg';
@@ -85,7 +83,7 @@ function signRefresh(
       jti: randomUUID(),
       typ: 'refresh',
       iat: now,
-      exp: now + REFRESH_SESSION_LIFETIME_SECONDS,
+      exp: now + DEFAULT_AUTH_TIMING.refreshSessionTtlSeconds,
       ...claims,
     },
     secret,
@@ -124,7 +122,7 @@ describe('AuthSessionService', () => {
   it('issues standard claims and persists only a refresh digest', async () => {
     const transaction = createTransaction();
     const prisma = createPrisma(transaction);
-    const service = new AuthSessionService(prisma as never);
+    const service = new AuthSessionService(prisma as never, DEFAULT_AUTH_TIMING);
 
     const response = await service.issueSession(user);
     const access = tokenPayload(response.accessToken);
@@ -153,9 +151,11 @@ describe('AuthSessionService', () => {
       typ: 'refresh',
     });
     expect(access.jti).not.toBe(refresh.jti);
-    expect(access.exp! - access.iat!).toBe(ACCESS_TOKEN_LIFETIME_SECONDS);
+    expect(access.exp! - access.iat!).toBe(
+      DEFAULT_AUTH_TIMING.accessTokenTtlSeconds,
+    );
     expect(refresh.exp! - refresh.iat!).toBe(
-      REFRESH_SESSION_LIFETIME_SECONDS,
+      DEFAULT_AUTH_TIMING.refreshSessionTtlSeconds,
     );
 
     const persisted = transaction.refreshTokenRecord.create.mock.calls[0][0];
@@ -172,16 +172,35 @@ describe('AuthSessionService', () => {
     ).not.toContain(response.refreshToken);
   });
 
+  it('mints tokens using the injected access and session lifetimes', async () => {
+    const transaction = createTransaction();
+    const prisma = createPrisma(transaction);
+    // The automated analogue of the manual 30s-TTL proof: a non-default timing
+    // must actually reach the minted token, not just parse at boot.
+    const service = new AuthSessionService(prisma as never, {
+      ...DEFAULT_AUTH_TIMING,
+      accessTokenTtlSeconds: 30,
+      refreshSessionTtlSeconds: 120,
+    });
+
+    const response = await service.issueSession(user);
+    const access = tokenPayload(response.accessToken);
+    const refresh = tokenPayload(response.refreshToken);
+
+    expect(access.exp! - access.iat!).toBe(30);
+    expect(refresh.exp! - refresh.iat!).toBe(120);
+  });
+
   it('evicts the least recently used session before creating session six', async () => {
     const transaction = createTransaction();
     const existing = Array.from(
-      { length: MAX_ACTIVE_SESSIONS_PER_USER },
+      { length: DEFAULT_AUTH_TIMING.maxActiveSessionsPerUser },
       () => ({ id: randomUUID() }),
     );
     transaction.authSession.findMany.mockResolvedValueOnce([]);
     transaction.authSession.findMany.mockResolvedValueOnce(existing);
     const prisma = createPrisma(transaction);
-    const service = new AuthSessionService(prisma as never);
+    const service = new AuthSessionService(prisma as never, DEFAULT_AUTH_TIMING);
 
     await service.issueSession(user);
 
@@ -231,7 +250,7 @@ describe('AuthSessionService', () => {
     const transaction = createTransaction();
     transaction.refreshTokenRecord.findUnique.mockResolvedValue(record);
     const prisma = createPrisma(transaction);
-    const service = new AuthSessionService(prisma as never);
+    const service = new AuthSessionService(prisma as never, DEFAULT_AUTH_TIMING);
 
     const response = await service.rotateRefreshToken(rawToken);
     const replacement = tokenPayload(response.refreshToken);
@@ -306,7 +325,7 @@ describe('AuthSessionService', () => {
         throw error;
       }
     });
-    const service = new AuthSessionService(prisma as never);
+    const service = new AuthSessionService(prisma as never, DEFAULT_AUTH_TIMING);
 
     await expect(service.rotateRefreshToken(rawToken)).rejects.toMatchObject({
       code: 'AUTH_REFRESH_INVALID',
@@ -346,7 +365,10 @@ describe('AuthSessionService', () => {
         user,
       },
     });
-    const service = new AuthSessionService(createPrisma(transaction) as never);
+    const service = new AuthSessionService(
+      createPrisma(transaction) as never,
+      DEFAULT_AUTH_TIMING,
+    );
 
     await expect(service.rotateRefreshToken(rawToken)).rejects.toMatchObject({
       code: 'AUTH_REFRESH_INVALID',
@@ -373,7 +395,7 @@ describe('AuthSessionService', () => {
   ])('maps %s to the same safe refresh error', async (_name, makeToken) => {
     const transaction = createTransaction();
     const prisma = createPrisma(transaction);
-    const service = new AuthSessionService(prisma as never);
+    const service = new AuthSessionService(prisma as never, DEFAULT_AUTH_TIMING);
 
     await expect(service.rotateRefreshToken(makeToken())).rejects.toMatchObject({
       code: 'AUTH_REFRESH_INVALID',
@@ -386,7 +408,7 @@ describe('AuthSessionService', () => {
   it('requires the access JWT session to remain active', async () => {
     const transaction = createTransaction();
     const prisma = createPrisma(transaction);
-    const service = new AuthSessionService(prisma as never);
+    const service = new AuthSessionService(prisma as never, DEFAULT_AUTH_TIMING);
     const response = await service.issueSession(user);
     prisma.authSession.findFirst.mockResolvedValue(null);
 

--- a/RythmRun_backend_nodejs/src/__tests__/env.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/env.test.ts
@@ -1,8 +1,11 @@
 import {
+  DEFAULT_AUTH_TIMING,
   EnvironmentValidationError,
   MAX_TRUST_PROXY_HOPS,
   MINIMUM_JWT_SECRET_LENGTH,
   getJwtSecrets,
+  parseAuthTiming,
+  parseRetrySweepIntervalSeconds,
   validateEmailEnvironment,
   validateHttpSecurityEnvironment,
   validateJwtSecrets,
@@ -358,4 +361,95 @@ describe('HTTP security environment validation', () => {
       validateHttpSecurityEnvironment({ CORS_ALLOWED_ORIGINS: '*' }),
     ).toThrow(EnvironmentValidationError);
   });
+});
+
+describe('auth timing environment validation', () => {
+  const AUTH_TIMING_CASES = [
+    { env: 'ACCESS_TOKEN_TTL_SECONDS', field: 'accessTokenTtlSeconds', min: 30, max: 86400 },
+    { env: 'REFRESH_SESSION_TTL_SECONDS', field: 'refreshSessionTtlSeconds', min: 60, max: 7776000 },
+    { env: 'MAX_ACTIVE_SESSIONS_PER_USER', field: 'maxActiveSessionsPerUser', min: 1, max: 100 },
+    { env: 'REFRESH_REUSE_GRACE_SECONDS', field: 'refreshReuseGraceSeconds', min: 0, max: 300 },
+    { env: 'EMAIL_VERIFICATION_TTL_SECONDS', field: 'emailVerificationTtlSeconds', min: 60, max: 604800 },
+    { env: 'EMAIL_VERIFICATION_COOLDOWN_SECONDS', field: 'emailVerificationCooldownSeconds', min: 0, max: 3600 },
+    { env: 'PASSWORD_RESET_TTL_SECONDS', field: 'passwordResetTtlSeconds', min: 60, max: 86400 },
+    { env: 'PASSWORD_RESET_COOLDOWN_SECONDS', field: 'passwordResetCooldownSeconds', min: 0, max: 3600 },
+  ] as const;
+
+  it('returns the shipped defaults when nothing is set', () => {
+    expect(parseAuthTiming({})).toEqual(DEFAULT_AUTH_TIMING);
+  });
+
+  it('treats a blank value as unset and falls back to the default', () => {
+    expect(parseAuthTiming({ ACCESS_TOKEN_TTL_SECONDS: '   ' })).toEqual(
+      DEFAULT_AUTH_TIMING,
+    );
+  });
+
+  it.each(AUTH_TIMING_CASES)(
+    'applies an in-range override for $env without disturbing the others',
+    ({ env, field, min }) => {
+      const override = min + 1;
+      expect(parseAuthTiming({ [env]: String(override) })).toEqual({
+        ...DEFAULT_AUTH_TIMING,
+        [field]: override,
+      });
+    },
+  );
+
+  it.each(AUTH_TIMING_CASES)(
+    'accepts the exact min and max bounds for $env',
+    ({ env, field, min, max }) => {
+      expect(parseAuthTiming({ [env]: String(min) })[field]).toBe(min);
+      expect(parseAuthTiming({ [env]: String(max) })[field]).toBe(max);
+    },
+  );
+
+  it.each(AUTH_TIMING_CASES)(
+    'rejects an out-of-range or non-integer $env',
+    ({ env, min, max }) => {
+      for (const bad of [String(min - 1), String(max + 1), '1.5', 'abc']) {
+        expect(() => parseAuthTiming({ [env]: bad })).toThrow(
+          `${env} must be an integer between ${min} and ${max}`,
+        );
+      }
+    },
+  );
+
+  it('raises a typed configuration error', () => {
+    expect(() => parseAuthTiming({ ACCESS_TOKEN_TTL_SECONDS: '0' })).toThrow(
+      EnvironmentValidationError,
+    );
+  });
+});
+
+describe('retry sweep interval validation', () => {
+  it('defaults to 900 seconds when unset or blank', () => {
+    expect(parseRetrySweepIntervalSeconds({})).toBe(900);
+    expect(
+      parseRetrySweepIntervalSeconds({ RETRY_SWEEP_INTERVAL_SECONDS: '' }),
+    ).toBe(900);
+  });
+
+  it('applies an in-range override and accepts the bounds', () => {
+    expect(
+      parseRetrySweepIntervalSeconds({ RETRY_SWEEP_INTERVAL_SECONDS: '60' }),
+    ).toBe(60);
+    expect(
+      parseRetrySweepIntervalSeconds({ RETRY_SWEEP_INTERVAL_SECONDS: '10' }),
+    ).toBe(10);
+    expect(
+      parseRetrySweepIntervalSeconds({ RETRY_SWEEP_INTERVAL_SECONDS: '86400' }),
+    ).toBe(86400);
+  });
+
+  it.each(['9', '86401', '1.5', 'abc'])(
+    'rejects an unusable RETRY_SWEEP_INTERVAL_SECONDS: %s',
+    (value) => {
+      expect(() =>
+        parseRetrySweepIntervalSeconds({ RETRY_SWEEP_INTERVAL_SECONDS: value }),
+      ).toThrow(
+        'RETRY_SWEEP_INTERVAL_SECONDS must be an integer between 10 and 86400',
+      );
+    },
+  );
 });

--- a/RythmRun_backend_nodejs/src/__tests__/server-bootstrap.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/server-bootstrap.test.ts
@@ -68,6 +68,19 @@ jest.unstable_mockModule('../config/env.js', () => ({
     mockEvents.push('validate-http-security');
     return { allowedOrigins: [], trustProxyHops: 0 };
   }),
+  // configureContainer is mocked below and ignores the injected timing, so
+  // these only need to return well-shaped values, not real parsing.
+  parseAuthTiming: jest.fn(() => ({
+    accessTokenTtlSeconds: 900,
+    refreshSessionTtlSeconds: 604800,
+    maxActiveSessionsPerUser: 5,
+    refreshReuseGraceSeconds: 60,
+    emailVerificationTtlSeconds: 86400,
+    emailVerificationCooldownSeconds: 60,
+    passwordResetTtlSeconds: 1800,
+    passwordResetCooldownSeconds: 60,
+  })),
+  parseRetrySweepIntervalSeconds: jest.fn(() => 900),
 }));
 
 jest.unstable_mockModule('../app.js', () => {

--- a/RythmRun_backend_nodejs/src/__tests__/user-auth.service.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/user-auth.service.test.ts
@@ -1,6 +1,8 @@
 import 'reflect-metadata';
 import { jest } from '@jest/globals';
 
+import { DEFAULT_AUTH_TIMING } from '../config/env.js';
+
 jest.unstable_mockModule('bcrypt', () => ({
   hash: jest.fn(),
   compare: jest.fn(),
@@ -111,6 +113,7 @@ function harness() {
     service: new UserService(
       prisma as never,
       authSessions as never,
+      DEFAULT_AUTH_TIMING,
       googleIdentityVerifier,
       emailSender as never,
     ),

--- a/RythmRun_backend_nodejs/src/__tests__/user-input-hardening.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/user-input-hardening.test.ts
@@ -12,6 +12,7 @@ import {
     RegisterUserDto,
     UpdateProfileDto
 } from '../models/dto/user.dto.js';
+import { DEFAULT_AUTH_TIMING } from '../config/env.js';
 const bcrypt = await import('bcrypt');
 const { UserService } = await import('../services/user.service.js');
 
@@ -204,7 +205,7 @@ describe('UserService writable-field mapping', () => {
             }
         };
         const authSessions = createMockAuthSessions(transaction);
-        const service = new UserService(prisma as any, authSessions as any);
+        const service = new UserService(prisma as any, authSessions as any, DEFAULT_AUTH_TIMING);
         const dto = Object.assign(new RegisterUserDto(), {
             username: 'ada@example.com',
             password: 'correct-horse-battery-staple',
@@ -251,7 +252,7 @@ describe('UserService writable-field mapping', () => {
             lastname: 'King'
         });
         const authSessions = createMockAuthSessions({});
-        const service = new UserService(prisma as any, authSessions as any);
+        const service = new UserService(prisma as any, authSessions as any, DEFAULT_AUTH_TIMING);
         const dto = Object.assign(new UpdateProfileDto(), {
             firstname: 'Augusta Ada',
             lastname: 'King',
@@ -293,7 +294,8 @@ describe('UserService writable-field mapping', () => {
         );
         const service = new UserService(
             prisma as any,
-            createMockAuthSessions({}) as any
+            createMockAuthSessions({}) as any,
+            DEFAULT_AUTH_TIMING
         );
 
         await expect(

--- a/RythmRun_backend_nodejs/src/config/container.ts
+++ b/RythmRun_backend_nodejs/src/config/container.ts
@@ -12,7 +12,7 @@ import { AvatarService } from '../services/avatar.service.js';
 import { AuthSessionService } from '../services/auth-session.service.js';
 import { GoogleAuthService } from '../services/google-auth.service.js';
 import { createEmailSender } from '../services/email.service.js';
-import type { EmailEnvironment } from './env.js';
+import type { AuthTimingEnvironment, EmailEnvironment } from './env.js';
 import s3Service from '../services/s3.service.js';
 
 export const container = rootContainer.createChildContainer();
@@ -21,6 +21,7 @@ let configured = false;
 export function configureContainer(
   databaseUrl: string,
   googleServerClientId: string,
+  authTiming: AuthTimingEnvironment,
   emailConfig: EmailEnvironment | null = null,
 ): DatabaseRuntime {
   if (configured) {
@@ -29,6 +30,7 @@ export function configureContainer(
 
   const database = createDatabase(databaseUrl);
   container.registerInstance('PrismaClient', database.client);
+  container.registerInstance('AuthTiming', authTiming);
   container.registerInstance('S3Service', s3Service);
   container.registerInstance(
     'GoogleIdentityVerifier',

--- a/RythmRun_backend_nodejs/src/config/env.ts
+++ b/RythmRun_backend_nodejs/src/config/env.ts
@@ -51,6 +51,47 @@ export interface HttpSecurityEnvironment {
   trustProxyHops: number;
 }
 
+/**
+ * Tunable auth timing. Every field replaces a value that used to be hardcoded in
+ * a service, so the defaults reproduce today's behavior exactly. Resolved once at
+ * boot from the environment and injected as 'AuthTiming' into AuthSessionService
+ * and UserService, so a deployment can force a real-world scenario (a 30-second
+ * access token, a 1-minute session) without a code change.
+ *
+ * `RETRY_SWEEP_INTERVAL_SECONDS` is deliberately absent: no service reads it, so
+ * it is parsed at bootstrap by parseRetrySweepIntervalSeconds and used directly in
+ * server.ts rather than injected here.
+ */
+export interface AuthTimingEnvironment {
+  accessTokenTtlSeconds: number;
+  refreshSessionTtlSeconds: number;
+  maxActiveSessionsPerUser: number;
+  // Consumed in Phase 2 (refresh reuse grace window); parsed now so the spine is
+  // complete and Phase 2 is a behavior-only change.
+  refreshReuseGraceSeconds: number;
+  emailVerificationTtlSeconds: number;
+  emailVerificationCooldownSeconds: number;
+  passwordResetTtlSeconds: number;
+  passwordResetCooldownSeconds: number;
+}
+
+/**
+ * The timing values the services shipped with before they became tunable. This
+ * is the single source of truth for the defaults: parseAuthTiming reads each
+ * field as its fallback, and unit tests that construct the services directly
+ * (bypassing the DI container) inject this constant.
+ */
+export const DEFAULT_AUTH_TIMING: AuthTimingEnvironment = {
+  accessTokenTtlSeconds: 900,
+  refreshSessionTtlSeconds: 604800,
+  maxActiveSessionsPerUser: 5,
+  refreshReuseGraceSeconds: 60,
+  emailVerificationTtlSeconds: 86400,
+  emailVerificationCooldownSeconds: 60,
+  passwordResetTtlSeconds: 1800,
+  passwordResetCooldownSeconds: 60,
+};
+
 export const HTTP_SECURITY_ENVIRONMENT_VARIABLES = [
   'CORS_ALLOWED_ORIGINS',
   'TRUST_PROXY_HOPS',
@@ -418,6 +459,100 @@ function parseTrustProxyHops(source: EnvironmentSource): number {
   }
 
   return hops;
+}
+
+/**
+ * Parses one optional integer environment variable. Absent or blank falls back
+ * to the default; anything present must be an integer inside [min, max] or boot
+ * fails closed. The bounds are typo protection, not policy —
+ * `ACCESS_TOKEN_TTL_SECONDS=9000000` should stop the boot, not silently mint a
+ * three-month token.
+ */
+function parseIntEnv(
+  source: EnvironmentSource,
+  name: string,
+  bounds: { fallback: number; min: number; max: number },
+): number {
+  const raw = source[name];
+  if (raw === undefined || raw.trim().length === 0) {
+    return bounds.fallback;
+  }
+
+  const value = Number(raw.trim());
+  if (!Number.isInteger(value) || value < bounds.min || value > bounds.max) {
+    throw new EnvironmentValidationError(
+      `${name} must be an integer between ${bounds.min} and ${bounds.max}`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Resolves the tunable auth timing knobs once at boot. Each fallback comes from
+ * DEFAULT_AUTH_TIMING so the defaults live in exactly one place; the bounds are
+ * per-variable here.
+ */
+export function parseAuthTiming(
+  source: EnvironmentSource,
+): AuthTimingEnvironment {
+  return {
+    accessTokenTtlSeconds: parseIntEnv(source, 'ACCESS_TOKEN_TTL_SECONDS', {
+      fallback: DEFAULT_AUTH_TIMING.accessTokenTtlSeconds,
+      min: 30,
+      max: 86400,
+    }),
+    refreshSessionTtlSeconds: parseIntEnv(
+      source,
+      'REFRESH_SESSION_TTL_SECONDS',
+      { fallback: DEFAULT_AUTH_TIMING.refreshSessionTtlSeconds, min: 60, max: 7776000 },
+    ),
+    maxActiveSessionsPerUser: parseIntEnv(
+      source,
+      'MAX_ACTIVE_SESSIONS_PER_USER',
+      { fallback: DEFAULT_AUTH_TIMING.maxActiveSessionsPerUser, min: 1, max: 100 },
+    ),
+    refreshReuseGraceSeconds: parseIntEnv(
+      source,
+      'REFRESH_REUSE_GRACE_SECONDS',
+      { fallback: DEFAULT_AUTH_TIMING.refreshReuseGraceSeconds, min: 0, max: 300 },
+    ),
+    emailVerificationTtlSeconds: parseIntEnv(
+      source,
+      'EMAIL_VERIFICATION_TTL_SECONDS',
+      { fallback: DEFAULT_AUTH_TIMING.emailVerificationTtlSeconds, min: 60, max: 604800 },
+    ),
+    emailVerificationCooldownSeconds: parseIntEnv(
+      source,
+      'EMAIL_VERIFICATION_COOLDOWN_SECONDS',
+      { fallback: DEFAULT_AUTH_TIMING.emailVerificationCooldownSeconds, min: 0, max: 3600 },
+    ),
+    passwordResetTtlSeconds: parseIntEnv(
+      source,
+      'PASSWORD_RESET_TTL_SECONDS',
+      { fallback: DEFAULT_AUTH_TIMING.passwordResetTtlSeconds, min: 60, max: 86400 },
+    ),
+    passwordResetCooldownSeconds: parseIntEnv(
+      source,
+      'PASSWORD_RESET_COOLDOWN_SECONDS',
+      { fallback: DEFAULT_AUTH_TIMING.passwordResetCooldownSeconds, min: 0, max: 3600 },
+    ),
+  };
+}
+
+/**
+ * The background sweep interval (expired sessions/tokens, pending media
+ * cleanup). Bootstrap-only — no service reads it — so it is parsed here and used
+ * directly by the sweep timer in server.ts rather than injected with the auth
+ * timing knobs.
+ */
+export function parseRetrySweepIntervalSeconds(
+  source: EnvironmentSource,
+): number {
+  return parseIntEnv(source, 'RETRY_SWEEP_INTERVAL_SECONDS', {
+    fallback: 900,
+    min: 10,
+    max: 86400,
+  });
 }
 
 /**

--- a/RythmRun_backend_nodejs/src/server.ts
+++ b/RythmRun_backend_nodejs/src/server.ts
@@ -4,6 +4,8 @@ import os from 'node:os';
 
 import {
   loadAndValidateEnvironment,
+  parseAuthTiming,
+  parseRetrySweepIntervalSeconds,
   validateEmailEnvironment,
   validateHttpSecurityEnvironment,
 } from './config/env.js';
@@ -117,6 +119,11 @@ export async function startServer(
   // Fails closed in production: a missing CORS allowlist stops the boot rather
   // than falling back to the permissive policy this app used before IP-2.6.
   const httpSecurity = validateHttpSecurityEnvironment(process.env);
+  // Tunable auth timing, resolved once and injected; the sweep interval is
+  // bootstrap-only and used directly below.
+  const authTiming = parseAuthTiming(process.env);
+  const retrySweepIntervalMs =
+    parseRetrySweepIntervalSeconds(process.env) * 1000;
   const port = getPort(options.port);
   let database: DatabaseRuntime | undefined;
 
@@ -127,6 +134,7 @@ export async function startServer(
     database = configureContainer(
       environment.DATABASE_URL,
       environment.GOOGLE_SERVER_CLIENT_ID,
+      authTiming,
       emailConfig,
     );
 
@@ -203,7 +211,7 @@ export async function startServer(
           .purgeExpiredVerificationTokens()
           .then(() => undefined),
       );
-    }, options.retryIntervalMs ?? 15 * 60 * 1000);
+    }, options.retryIntervalMs ?? retrySweepIntervalMs);
     retryTimer.unref();
 
     const cleanup = createRuntimeCleanup(retryTimer, database);

--- a/RythmRun_backend_nodejs/src/services/auth-session.service.ts
+++ b/RythmRun_backend_nodejs/src/services/auth-session.service.ts
@@ -3,7 +3,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import jwt from 'jsonwebtoken';
 import { inject, injectable } from 'tsyringe';
 
-import { getJwtSecrets } from '../config/env.js';
+import { getJwtSecrets, type AuthTimingEnvironment } from '../config/env.js';
 import {
   Prisma,
   type PrismaClient,
@@ -14,9 +14,6 @@ import {
   invalidRefreshError,
 } from '../errors/auth.error.js';
 
-export const ACCESS_TOKEN_LIFETIME_SECONDS = 15 * 60;
-export const REFRESH_SESSION_LIFETIME_SECONDS = 7 * 24 * 60 * 60;
-export const MAX_ACTIVE_SESSIONS_PER_USER = 5;
 export const REFRESH_DIGEST_ALGORITHM = 'sha256';
 
 const MAX_SERIALIZABLE_ATTEMPTS = 3;
@@ -100,7 +97,10 @@ export function toSafeUserResponse(user: User): SafeUserResponse {
 
 @injectable()
 export class AuthSessionService {
-  constructor(@inject('PrismaClient') private readonly prisma: PrismaClient) {}
+  constructor(
+    @inject('PrismaClient') private readonly prisma: PrismaClient,
+    @inject('AuthTiming') private readonly authTiming: AuthTimingEnvironment,
+  ) {}
 
   async withSerializableTransaction<T>(
     operation: (transaction: TransactionClient) => Promise<T>,
@@ -152,7 +152,7 @@ export class AuthSessionService {
       select: { id: true },
     });
     const overflowCount =
-      activeSessions.length - MAX_ACTIVE_SESSIONS_PER_USER + 1;
+      activeSessions.length - this.authTiming.maxActiveSessionsPerUser + 1;
     if (overflowCount > 0) {
       await this.revokeSessionIdsInTransaction(
         transaction,
@@ -166,7 +166,7 @@ export class AuthSessionService {
     const sessionId = randomUUID();
     const familyId = randomUUID();
     const expiresAt = new Date(
-      now.getTime() + REFRESH_SESSION_LIFETIME_SECONDS * 1000,
+      now.getTime() + this.authTiming.refreshSessionTtlSeconds * 1000,
     );
     const tokenPair = this.createTokenPair(user.id, sessionId, expiresAt, now);
 
@@ -445,7 +445,7 @@ export class AuthSessionService {
       typ: 'access',
       iat: issuedAt,
       exp: Math.min(
-        issuedAt + ACCESS_TOKEN_LIFETIME_SECONDS,
+        issuedAt + this.authTiming.accessTokenTtlSeconds,
         sessionExpiry,
       ),
     };

--- a/RythmRun_backend_nodejs/src/services/user.service.ts
+++ b/RythmRun_backend_nodejs/src/services/user.service.ts
@@ -19,6 +19,7 @@ import {
   accountDeletionReauthRequiredError,
 } from '../errors/account-deletion.error.js';
 import { Prisma, type PrismaClient } from '../generated/prisma/client.js';
+import type { AuthTimingEnvironment } from '../config/env.js';
 import {
   ChangePasswordDto,
   DeleteAccountDto,
@@ -39,12 +40,8 @@ import type { EmailSender } from './email.service.js';
 import type { GoogleIdentityVerifier } from './google-auth.service.js';
 
 const SALT_ROUNDS = 10;
-const VERIFICATION_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
-const VERIFICATION_RESEND_COOLDOWN_MS = 60 * 1000;
 const EMAIL_VERIFICATION_PURPOSE = 'EMAIL_VERIFICATION' as const;
 const PASSWORD_RESET_PURPOSE = 'PASSWORD_RESET' as const;
-const PASSWORD_RESET_TTL_MS = 30 * 60 * 1000;
-const PASSWORD_RESET_COOLDOWN_MS = 60 * 1000;
 
 type VerificationPurpose =
   | typeof EMAIL_VERIFICATION_PURPOSE
@@ -80,6 +77,7 @@ export class UserService {
     @inject('PrismaClient') private readonly prisma: PrismaClient,
     @inject('AuthSessionService')
     private readonly authSessions: AuthSessionService,
+    @inject('AuthTiming') private readonly authTiming: AuthTimingEnvironment,
     @inject('GoogleIdentityVerifier')
     private readonly googleIdentityVerifier?: GoogleIdentityVerifier,
     @inject('EmailSender')
@@ -118,7 +116,7 @@ export class UserService {
             transaction,
             user.id,
             EMAIL_VERIFICATION_PURPOSE,
-            VERIFICATION_TOKEN_TTL_MS,
+            this.authTiming.emailVerificationTtlSeconds * 1000,
           );
           return {
             response,
@@ -240,7 +238,7 @@ export class UserService {
     if (
       existing?.lastSentAt != null &&
       Date.now() - existing.lastSentAt.getTime() <
-        VERIFICATION_RESEND_COOLDOWN_MS
+        this.authTiming.emailVerificationCooldownSeconds * 1000
     ) {
       throw verificationRateLimitedError();
     }
@@ -251,7 +249,7 @@ export class UserService {
           transaction,
           userId,
           EMAIL_VERIFICATION_PURPOSE,
-          VERIFICATION_TOKEN_TTL_MS,
+          this.authTiming.emailVerificationTtlSeconds * 1000,
         ),
     );
     await this.deliverVerificationEmail(
@@ -284,7 +282,8 @@ export class UserService {
     });
     if (
       existing?.lastSentAt != null &&
-      Date.now() - existing.lastSentAt.getTime() < PASSWORD_RESET_COOLDOWN_MS
+      Date.now() - existing.lastSentAt.getTime() <
+        this.authTiming.passwordResetCooldownSeconds * 1000
     ) {
       return;
     }
@@ -295,7 +294,7 @@ export class UserService {
           transaction,
           user.id,
           PASSWORD_RESET_PURPOSE,
-          PASSWORD_RESET_TTL_MS,
+          this.authTiming.passwordResetTtlSeconds * 1000,
         ),
     );
     await this.deliverPasswordResetEmail(

--- a/docs/_engineering/auth-hardening/MASTER-PLAN.md
+++ b/docs/_engineering/auth-hardening/MASTER-PLAN.md
@@ -4,7 +4,7 @@ published: false
 
 # Auth Hardening & Tunable Timing — Master Plan
 
-**Status:** Phase 0 not started · **Owner:** maintainer · **Created:** 2026-08-11
+**Status:** Phase 0 complete — awaiting review · **Owner:** maintainer · **Created:** 2026-08-11
 **Source:** auth + refresh audit (16 confirmed findings, 1 plausible, 2 refuted)
 **Relationship to the improvement program:** this is IP-2 follow-up work. It does
 not replace `IP-2-auth-account-privacy.md`; when a phase here lands, its evidence
@@ -619,14 +619,14 @@ New tests: a request completing across a rotation returns its result; a failed f
 Legend: `[ ]` pending · `[~]` in progress · `[x]` done
 
 ### Phase 0 — Configuration spine
-- [ ] `parseIntEnv` helper + `AuthTimingEnvironment` in `env.ts`
-- [ ] Nine env vars parsed with defaults + bounds
-- [ ] DI registration + injection into `AuthSessionService` / `UserService`
-- [ ] `RETRY_SWEEP_INTERVAL_SECONDS` in `server.ts`
-- [ ] `.env.example` documented
-- [ ] Client: `offlineWindow`, `clockSkewTolerance`, `needsBackendSync`, `REQUEST_TIMEOUT_MS`
-- [ ] `CONFIGURATION.md` auth-timing section
-- [ ] Both suites green · manual 30s-TTL proof
+- [x] `parseIntEnv` helper + `AuthTimingEnvironment` in `env.ts`
+- [x] Nine env vars parsed with defaults + bounds
+- [x] DI registration + injection into `AuthSessionService` / `UserService`
+- [x] `RETRY_SWEEP_INTERVAL_SECONDS` in `server.ts`
+- [x] `.env.example` documented
+- [x] Client: `offlineWindow`, `clockSkewTolerance`, `needsBackendSync`, `REQUEST_TIMEOUT_MS`
+- [x] `CONFIGURATION.md` auth-timing section
+- [~] Both suites green (automated ✅) · manual 30s-TTL proof is a maintainer deploy check
 
 ### Phase 1 — Backend containment
 - [ ] **M5** cleanup runner scheduled + DI-resolved
@@ -693,8 +693,11 @@ flutter analyze --no-pub --no-fatal-infos
 dart format --set-exit-if-changed <changed files only>
 ```
 
-**Baseline to hold or beat:** backend 464 passed / 7 skipped / 471 total ·
-Flutter 359 passed · analyzer 9 issues, 0 warnings, 0 errors.
+**Baseline to hold or beat:** backend 473 passed / 7 skipped / 480 total ·
+Flutter 359 passed · analyzer 9 issues, 0 warnings, 0 errors. (The prior
+`464 / 7 / 471` figure was stale — the Phase 0 lock-baseline step measured the
+true starting point. Phase 0 adds config-spine tests, taking the backend to
+507 passed / 7 skipped / 514 total with Flutter unchanged at 359.)
 
 **Four known traps** (from `CLAUDE.md`, repeated because they cost real time):
 1. Use `npm test`, never `npx jest` — the suite is native ESM.

--- a/rythmrun_frontend_flutter/CONFIGURATION.md
+++ b/rythmrun_frontend_flutter/CONFIGURATION.md
@@ -190,6 +190,46 @@ flutter run --release
 - **Error Classification**: Different exception types for different error scenarios
 - **Connection Pooling**: Efficient HTTP client reuse
 
+## Auth timing overrides
+
+Auth timing is tunable so real-world scenarios can be forced on demand instead of
+simulated in tests — for example, proving a lost refresh response recovers by
+shrinking a 15-minute access token to 30 seconds. The knobs split into two
+families by *where* the value lives.
+
+### Backend env vars are the live lever
+
+Token and session lifetimes are backend environment variables (documented in
+`RythmRun_backend_nodejs/.env.example`). The client never hardcodes a token
+lifetime — it reads the `exp` claim straight out of the JWT — so **changing a
+backend TTL and restarting immediately changes the installed app's refresh
+cadence, with no rebuild or reinstall.** That makes the backend the primary
+live-testing lever. For example: set `ACCESS_TOKEN_TTL_SECONDS=30` on the
+deployment, sign in on the installed app, wait 30s, make a request → the app
+refreshes once and the retry succeeds.
+
+### Client dart-defines are compile-time policy
+
+Four client-side policies are *not* derived from the token, so they are set at
+build time with `--dart-define`. They are baked into the binary: an override
+cannot be changed on an installed Play build, which is exactly why the backend
+knobs — not these — are the live lever. Every default reproduces the previous
+hardcoded behavior, so an unset build is unchanged.
+
+| Define | Default | Controls |
+| --- | --- | --- |
+| `OFFLINE_WINDOW_HOURS` | `168` (7d) | Max offline access after a successful server verification (D-009) |
+| `CLOCK_SKEW_TOLERANCE_SECONDS` | `120` (2m) | Tolerance before a clock rollback fails offline admission closed |
+| `BACKEND_SYNC_INTERVAL_HOURS` | `168` (7d) | Default cadence of periodic backend reconciliation |
+| `REQUEST_TIMEOUT_MS` | per-env map | Overrides the environment HTTP timeout when positive (`0` = keep the env value) |
+
+```bash
+# Force the offline re-verification path and a short request timeout in a test build
+flutter run \
+  --dart-define=OFFLINE_WINDOW_HOURS=1 \
+  --dart-define=REQUEST_TIMEOUT_MS=3000
+```
+
 ## Google sign-in configuration
 
 Google sign-in exchanges a Google ID token at

--- a/rythmrun_frontend_flutter/lib/core/config/app_config.dart
+++ b/rythmrun_frontend_flutter/lib/core/config/app_config.dart
@@ -30,6 +30,15 @@ class AppConfig {
     'prod': 10000, // 10 seconds for prod
   };
 
+  /// Optional HTTP timeout override. Compile-time
+  /// (`--dart-define=REQUEST_TIMEOUT_MS=<ms>`); when positive it wins over the
+  /// per-environment default so a test build can force a short timeout. 0 (the
+  /// default) means unset — keep the environment value.
+  static const int _requestTimeoutMsOverride = int.fromEnvironment(
+    'REQUEST_TIMEOUT_MS',
+    defaultValue: 0,
+  );
+
   // Environment detection
   static String get _environment {
     const appEnv = String.fromEnvironment('APP_ENV');
@@ -58,6 +67,9 @@ class AppConfig {
 
   /// Get the timeout duration for HTTP requests
   static Duration get timeout {
+    if (_requestTimeoutMsOverride > 0) {
+      return Duration(milliseconds: _requestTimeoutMsOverride);
+    }
     final env = _environment;
     final timeoutMs = _timeouts[env] ?? 30000; // Default to 30 seconds
     return Duration(milliseconds: timeoutMs);

--- a/rythmrun_frontend_flutter/lib/core/services/auth_persistence_service.dart
+++ b/rythmrun_frontend_flutter/lib/core/services/auth_persistence_service.dart
@@ -85,13 +85,39 @@ class AuthPersistenceService {
   static const String lastBackendSyncKey = 'last_backend_sync';
   static const String authCleanupPendingKey = 'auth_cleanup_pending';
 
+  // Auth timing knobs. Baked in at compile time (int.fromEnvironment), so an
+  // override needs a rebuild + reinstall — unlike the backend token/session
+  // TTLs, which the app follows live because it reads expiry from the JWT.
+  // Defaults reproduce today's behavior exactly.
+
   /// Maximum offline access after a successful server verification (D-009).
-  static const Duration offlineWindow = Duration(days: 7);
+  /// Override with `--dart-define=OFFLINE_WINDOW_HOURS=<n>` to force the
+  /// re-verification path in a test build.
+  static const int _offlineWindowHours = int.fromEnvironment(
+    'OFFLINE_WINDOW_HOURS',
+    defaultValue: 168,
+  );
+  static const Duration offlineWindow = Duration(hours: _offlineWindowHours);
 
   /// Small tolerance so benign NTP corrections do not force re-verification,
   /// while a meaningful clock rollback or future-dated verification still
   /// fails offline admission closed. Negligible against [offlineWindow].
-  static const Duration clockSkewTolerance = Duration(minutes: 2);
+  /// Override with `--dart-define=CLOCK_SKEW_TOLERANCE_SECONDS=<n>`.
+  static const int _clockSkewToleranceSeconds = int.fromEnvironment(
+    'CLOCK_SKEW_TOLERANCE_SECONDS',
+    defaultValue: 120,
+  );
+  static const Duration clockSkewTolerance = Duration(
+    seconds: _clockSkewToleranceSeconds,
+  );
+
+  /// Default cadence for the periodic backend reconciliation in
+  /// [needsBackendSync]. Override with
+  /// `--dart-define=BACKEND_SYNC_INTERVAL_HOURS=<n>`.
+  static const int _backendSyncIntervalHours = int.fromEnvironment(
+    'BACKEND_SYNC_INTERVAL_HOURS',
+    defaultValue: 168,
+  );
 
   static final RegExp _uuidPattern = RegExp(
     r'^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
@@ -309,7 +335,7 @@ class AuthPersistenceService {
   }
 
   Future<bool> needsBackendSync({
-    Duration syncInterval = const Duration(days: 7),
+    Duration syncInterval = const Duration(hours: _backendSyncIntervalHours),
   }) async {
     final lastSync = await getLastBackendSync();
     if (lastSync == null) return true;


### PR DESCRIPTION
…onfig spine)

Turn every hardcoded auth timing constant into a runtime (backend env) or compile-time (client dart-define) knob, so real-world scenarios can be forced on a deployment instead of only simulated in tests. Every default reproduces today's behavior exactly — no behavior change until a variable is set.

Backend (runtime env, fail-closed at boot):
- env.ts: parseIntEnv, AuthTimingEnvironment, DEFAULT_AUTH_TIMING (single source of defaults), parseAuthTiming, parseRetrySweepIntervalSeconds.
- Nine bounded vars; REFRESH_REUSE_GRACE_SECONDS is parsed now and consumed in Phase 2. Inject 'AuthTiming' (required, non-null) into AuthSessionService and UserService and rewire their use sites. The sweep interval is bootstrap-only, so it is parsed in server.ts rather than injected.
- .env.example documents all nine with defaults and ranges.

Client (compile-time dart-define, baked into the binary):
- auth_persistence_service.dart: offlineWindow, clockSkewTolerance and the needsBackendSync default become OFFLINE_WINDOW_HOURS, CLOCK_SKEW_TOLERANCE_SECONDS, BACKEND_SYNC_INTERVAL_HOURS.
- app_config.dart: REQUEST_TIMEOUT_MS override (0 = keep the env default).
- CONFIGURATION.md: new auth-timing section — the client reads token expiry from the JWT, so backend TTLs are the live lever.
