### PR TITLE
feat(auth): contain account deletion — schedule cleanup sweep + rate-…

### DIFF
--- a/RythmRun_backend_nodejs/src/__tests__/api-abuse-controls.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/api-abuse-controls.test.ts
@@ -121,6 +121,7 @@ const userService = {
   changePassword: jest.fn(),
   requestPasswordReset: jest.fn(),
   resendVerification: jest.fn(),
+  deleteAccount: jest.fn(),
 };
 
 const authenticate = jest.fn(
@@ -519,6 +520,52 @@ describe('IP-2.6 authentication rate limits', () => {
         { authorization: AUTHORIZATION },
       );
       expect(blocked.statusCode).toBe(429);
+    } finally {
+      await stop(server);
+    }
+  });
+
+  it('caps account-deletion re-auth attempts behind authentication', async () => {
+    const server = await startTestServer();
+    userService.deleteAccount.mockResolvedValue(undefined);
+    const deleteBody = { password: 'correct-horse-battery-staple' };
+
+    try {
+      const unauthenticated = await request(
+        server,
+        'DELETE',
+        '/api/users/me',
+        deleteBody,
+      );
+      expect(unauthenticated.statusCode).toBe(401);
+
+      for (
+        let attempt = 0;
+        attempt < AUTH_RATE_LIMITS.accountDeletion.limit;
+        attempt += 1
+      ) {
+        const response = await request(
+          server,
+          'DELETE',
+          '/api/users/me',
+          deleteBody,
+          { authorization: AUTHORIZATION },
+        );
+        expect(response.statusCode).toBe(200);
+      }
+
+      const blocked = await request(
+        server,
+        'DELETE',
+        '/api/users/me',
+        deleteBody,
+        { authorization: AUTHORIZATION },
+      );
+      expect(blocked.statusCode).toBe(429);
+      expect(blocked.body).toMatchObject({
+        error: 'AUTH_RATE_LIMITED',
+        statusCode: 429,
+      });
     } finally {
       await stop(server);
     }

--- a/RythmRun_backend_nodejs/src/__tests__/server-bootstrap.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/server-bootstrap.test.ts
@@ -7,6 +7,7 @@ const mockRetryPendingDeletes = jest.fn().mockResolvedValue(undefined);
 const mockRetryPendingCleanup = jest.fn().mockResolvedValue(undefined);
 const mockPurgeExpiredSessions = jest.fn().mockResolvedValue(0);
 const mockPurgeExpiredVerificationTokens = jest.fn().mockResolvedValue(0);
+const mockProcessPendingJobs = jest.fn().mockResolvedValue(0);
 const mockResolve = jest.fn((token: string) => {
   if (token === 'ActivityImageService') {
     return { retryPendingDeletes: mockRetryPendingDeletes };
@@ -24,6 +25,10 @@ const mockResolve = jest.fn((token: string) => {
     return {
       purgeExpiredVerificationTokens: mockPurgeExpiredVerificationTokens,
     };
+  }
+
+  if (token === 'ObjectCleanupRunner') {
+    return { processPendingJobs: mockProcessPendingJobs };
   }
 
   throw new Error(`Unexpected service token: ${token}`);
@@ -185,10 +190,14 @@ describe('server bootstrap', () => {
     expect(mockResolve).toHaveBeenCalledWith('AvatarService');
     expect(mockResolve).toHaveBeenCalledWith('AuthSessionService');
     expect(mockResolve).toHaveBeenCalledWith('UserService');
+    expect(mockResolve).toHaveBeenCalledWith('ObjectCleanupRunner');
     expect(mockRetryPendingDeletes).toHaveBeenCalledTimes(1);
     expect(mockRetryPendingCleanup).toHaveBeenCalledTimes(1);
     expect(mockPurgeExpiredSessions).toHaveBeenCalledTimes(1);
     expect(mockPurgeExpiredVerificationTokens).toHaveBeenCalledTimes(1);
+    // The deletion outbox is drained on the same sweep, so a job whose first
+    // attempt failed is retried here instead of being stranded (M5).
+    expect(mockProcessPendingJobs).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(
       'Avatar cleanup retry failed (AvatarCleanupError)',
     );

--- a/RythmRun_backend_nodejs/src/config/container.ts
+++ b/RythmRun_backend_nodejs/src/config/container.ts
@@ -10,6 +10,7 @@ import { LikeService } from '../services/like.service.js';
 import { FriendService } from '../services/friend.service.js';
 import { AvatarService } from '../services/avatar.service.js';
 import { AuthSessionService } from '../services/auth-session.service.js';
+import { ObjectCleanupRunner } from '../services/object-cleanup.runner.js';
 import { GoogleAuthService } from '../services/google-auth.service.js';
 import { createEmailSender } from '../services/email.service.js';
 import type { AuthTimingEnvironment, EmailEnvironment } from './env.js';
@@ -50,6 +51,7 @@ export function configureContainer(
   container.register('LikeService', { useClass: LikeService });
   container.register('FriendService', { useClass: FriendService });
   container.register('AvatarService', { useClass: AvatarService });
+  container.register('ObjectCleanupRunner', { useClass: ObjectCleanupRunner });
 
   configured = true;
   return database;

--- a/RythmRun_backend_nodejs/src/config/rate-limits.ts
+++ b/RythmRun_backend_nodejs/src/config/rate-limits.ts
@@ -37,6 +37,7 @@ export const AUTH_RATE_LIMITS = {
   passwordResetSubmit: { limit: 10, windowMs: HOUR_MS },
   passwordChange: { limit: 5, windowMs: HOUR_MS },
   verificationResend: { limit: 5, windowMs: HOUR_MS },
+  accountDeletion: { limit: 5, windowMs: HOUR_MS },
 } as const;
 
 export const AUTH_RATE_LIMIT_RULES: readonly RateLimitRule[] = [
@@ -110,6 +111,16 @@ export const AUTH_RATE_LIMIT_RULES: readonly RateLimitRule[] = [
     count: 'all',
     key: authenticatedAccount,
   },
+  {
+    name: 'account-deletion',
+    category: 'auth.account_deletion',
+    ...AUTH_RATE_LIMITS.accountDeletion,
+    // Deletion re-authenticates (password or Google token). Charging every
+    // attempt, keyed by the proven user id, bounds re-auth guessing on a
+    // destructive endpoint — same shape as password-change.
+    count: 'all',
+    key: authenticatedAccount,
+  },
 ];
 
 export interface AuthRateLimiters {
@@ -121,6 +132,7 @@ export interface AuthRateLimiters {
   passwordResetSubmit: RequestHandler;
   passwordChange: RequestHandler;
   verificationResend: RequestHandler;
+  accountDeletion: RequestHandler;
 }
 
 const RULE_BY_NAME = new Map(AUTH_RATE_LIMIT_RULES.map((rule) => [rule.name, rule]));
@@ -158,6 +170,7 @@ export function createAuthRateLimiters(
     passwordResetSubmit: limiter('password-reset-submit', shared),
     passwordChange: limiter('password-change', shared),
     verificationResend: limiter('verification-resend', shared),
+    accountDeletion: limiter('account-deletion', shared),
   };
 }
 
@@ -173,5 +186,6 @@ export function createPassthroughRateLimiters(): AuthRateLimiters {
     passwordResetSubmit: passthrough,
     passwordChange: passthrough,
     verificationResend: passthrough,
+    accountDeletion: passthrough,
   };
 }

--- a/RythmRun_backend_nodejs/src/routes/user.routes.ts
+++ b/RythmRun_backend_nodejs/src/routes/user.routes.ts
@@ -187,7 +187,12 @@ export function createUserRouter({
    * @auth Required
    * @body {DeleteAccountDto} - password or googleIdToken
    */
-  router.delete('/me', authenticate, controller.deleteAccount);
+  router.delete(
+    '/me',
+    authenticate,
+    rateLimits.accountDeletion,
+    controller.deleteAccount,
+  );
 
   return router;
 }

--- a/RythmRun_backend_nodejs/src/server.ts
+++ b/RythmRun_backend_nodejs/src/server.ts
@@ -14,6 +14,7 @@ import type { ActivityImageService } from './services/activity-image.service.js'
 import type { AvatarService } from './services/avatar.service.js';
 import type { AuthSessionService } from './services/auth-session.service.js';
 import type { UserService } from './services/user.service.js';
+import type { ObjectCleanupRunner } from './services/object-cleanup.runner.js';
 
 export interface StartServerOptions {
   host?: string;
@@ -209,6 +210,15 @@ export async function startServer(
         container
           .resolve<UserService>('UserService')
           .purgeExpiredVerificationTokens()
+          .then(() => undefined),
+      );
+      // Drains the deletion outbox (avatar + activity-image removals queued by
+      // account deletion). This is the only scheduled runner for it, so a job
+      // whose first attempt failed is retried here instead of being stranded.
+      runRetry('Object cleanup', () =>
+        container
+          .resolve<ObjectCleanupRunner>('ObjectCleanupRunner')
+          .processPendingJobs()
           .then(() => undefined),
       );
     }, options.retryIntervalMs ?? retrySweepIntervalMs);

--- a/RythmRun_backend_nodejs/src/services/user.service.ts
+++ b/RythmRun_backend_nodejs/src/services/user.service.ts
@@ -28,7 +28,6 @@ import {
   RegisterUserDto,
   UpdateProfileDto,
 } from '../models/dto/user.dto.js';
-import { ObjectCleanupRunner } from './object-cleanup.runner.js';
 import {
   AuthSessionService,
   type AuthResponse,
@@ -772,10 +771,10 @@ export class UserService {
       });
     });
 
-    const runner = new ObjectCleanupRunner(this.prisma);
-    await runner.processPendingJobs().catch((err) => {
-      console.error('Asynchronous object cleanup runner error:', err);
-    });
+    // The queued avatar/activity-image removals are drained by the scheduled
+    // object-cleanup sweep (server.ts). Running the runner inline here was the
+    // only trigger before, so a first-attempt failure left jobs stranded (M5);
+    // it also logged raw storage errors that can carry a presigned URL.
   }
 }
 

--- a/RythmRun_backend_nodejs/src/utils/security-log.ts
+++ b/RythmRun_backend_nodejs/src/utils/security-log.ts
@@ -16,7 +16,8 @@ export type SecurityEventCategory =
   | 'auth.password_change'
   | 'auth.password_reset_request'
   | 'auth.password_reset_submit'
-  | 'auth.verification_resend';
+  | 'auth.verification_resend'
+  | 'auth.account_deletion';
 
 export type SecurityEventOutcome = 'rate_limited';
 

--- a/docs/_engineering/auth-hardening/MASTER-PLAN.md
+++ b/docs/_engineering/auth-hardening/MASTER-PLAN.md
@@ -4,7 +4,7 @@ published: false
 
 # Auth Hardening & Tunable Timing — Master Plan
 
-**Status:** Phase 0 complete — awaiting review · **Owner:** maintainer · **Created:** 2026-08-11
+**Status:** Phase 0 merged · Phase 1 complete — awaiting review · **Owner:** maintainer · **Created:** 2026-08-11
 **Source:** auth + refresh audit (16 confirmed findings, 1 plausible, 2 refuted)
 **Relationship to the improvement program:** this is IP-2 follow-up work. It does
 not replace `IP-2-auth-account-privacy.md`; when a phase here lands, its evidence
@@ -629,9 +629,9 @@ Legend: `[ ]` pending · `[~]` in progress · `[x]` done
 - [~] Both suites green (automated ✅) · manual 30s-TTL proof is a maintainer deploy check
 
 ### Phase 1 — Backend containment
-- [ ] **M5** cleanup runner scheduled + DI-resolved
-- [ ] **M3** `DELETE /me` rate limit
-- [ ] Tests for both
+- [x] **M5** cleanup runner scheduled on the sweep (DI-resolved in `server.ts`); inline post-deletion kick removed so the sweep is the single drain path (also drops a raw-error log on a storage path)
+- [x] **M3** `DELETE /me` rate limit — `accountDeletion` 5/hour, keyed by authenticated account, `count: 'all'`
+- [x] Tests: sweep drains the outbox (server-bootstrap); 6th deletion re-auth in an hour → `429` (api-abuse-controls)
 
 ### Phase 2 — Refresh grace window
 - [ ] **M1** grace branch in `rotateRefreshToken`
@@ -697,7 +697,8 @@ dart format --set-exit-if-changed <changed files only>
 Flutter 359 passed · analyzer 9 issues, 0 warnings, 0 errors. (The prior
 `464 / 7 / 471` figure was stale — the Phase 0 lock-baseline step measured the
 true starting point. Phase 0 adds config-spine tests, taking the backend to
-507 passed / 7 skipped / 514 total with Flutter unchanged at 359.)
+507 passed / 7 skipped / 514 total with Flutter unchanged at 359. Phase 1 adds
+the M5 sweep and M3 rate-limit tests → 508 passed / 7 skipped / 515 total.)
 
 **Four known traps** (from `CLAUDE.md`, repeated because they cost real time):
 1. Use `npm test`, never `npx jest` — the suite is native ESM.


### PR DESCRIPTION
…limit DELETE /me (Phase 1)

M5 — the object-cleanup runner had exactly one trigger: an inline best-effort call right after account deletion. If that first pass failed, the PENDING/FAILED jobs it left were never retried (no scheduled drain existed), so a deleted user's avatar and activity-image objects could sit in R2 forever. It also logged the raw runner error, which on a storage path can carry a presigned URL.

- container.ts: register ObjectCleanupRunner.
- server.ts: drain the outbox on the existing background sweep (a fifth runRetry), DI-resolved like the other four; failures log only a category.
- user.service.ts: delete the inline kick and its import. The deletion txn still enqueues the PENDING jobs (nextAttemptAt defaults to now), and the sweep drains them on the next interval. Behavior change: post-deletion R2 cleanup moves from immediate best-effort to the scheduled sweep (<= RETRY_SWEEP_INTERVAL_SECONDS, default 15m). The DB deletion is unchanged and still immediate.

M3 — DELETE /me was the only re-auth-gated endpoint with no rate limit, so its password/Google-token re-check could be brute-forced.

- rate-limits.ts: add accountDeletion (5/hour), keyed by the authenticated user id, count 'all' — same shape as password-change.
- security-log.ts: add the auth.account_deletion category.
- user.routes.ts: mount it after authenticate on DELETE /me.

Tests: the background sweep resolves ObjectCleanupRunner and drains the outbox (server-bootstrap); the 6th deletion re-auth within an hour returns 429 AUTH_RATE_LIMITED (api-abuse-controls).

Verification: typecheck clean, 508 passed / 7 skipped / 515 total, build + smoke green.