### PR TITLE
feat(auth): forgive lost-response refresh retries with a grace window…

### DIFF
--- a/RythmRun_backend_nodejs/src/__tests__/auth-session.service.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/auth-session.service.test.ts
@@ -47,11 +47,13 @@ function createTransaction(overrides: Record<string, unknown> = {}) {
       findMany: jest.fn().mockResolvedValue([]),
       findFirst: jest.fn(),
       create: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
       updateMany: jest.fn().mockResolvedValue({ count: 1 }),
     },
     refreshTokenRecord: {
       findUnique: jest.fn(),
       create: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
       updateMany: jest.fn().mockResolvedValue({ count: 1 }),
     },
     ...overrides,
@@ -89,6 +91,79 @@ function signRefresh(
     secret,
     { algorithm: 'HS256' },
   );
+}
+
+/**
+ * Builds a rotation where the presented refresh token is already used, so the
+ * grace-window branch is exercised. `successor` is what a lookup of the used
+ * token's replacement returns (null = no successor row).
+ */
+function setupGraceScenario(options: {
+  usedAt: Date;
+  successor: {
+    usedAt: Date | null;
+    revokedAt: Date | null;
+    expiresAt: Date;
+  } | null;
+  graceSeconds?: number;
+}) {
+  const sid = randomUUID();
+  const jti = randomUUID();
+  const successorJti = randomUUID();
+  const sessionExpiry = new Date(NOW.getTime() + 30 * 60 * 1000);
+  const rawToken = signRefresh({
+    sid,
+    jti,
+    exp: Math.floor(sessionExpiry.getTime() / 1000),
+  });
+  const record = {
+    jti,
+    sessionId: sid,
+    tokenDigest: digestRefreshToken(rawToken),
+    issuedAt: NOW,
+    expiresAt: sessionExpiry,
+    usedAt: options.usedAt,
+    revokedAt: null,
+    replacedByJti: successorJti,
+    session: {
+      id: sid,
+      userId: user.id,
+      familyId: randomUUID(),
+      status: 'ACTIVE',
+      createdAt: NOW,
+      lastUsedAt: NOW,
+      expiresAt: sessionExpiry,
+      revokedAt: null,
+      user,
+    },
+  };
+  const successor =
+    options.successor === null
+      ? null
+      : {
+          jti: successorJti,
+          sessionId: sid,
+          tokenDigest: 'x'.repeat(64),
+          issuedAt: NOW,
+          replacedByJti: null,
+          ...options.successor,
+        };
+  const transaction = createTransaction();
+  transaction.refreshTokenRecord.findUnique.mockImplementation(
+    async ({ where }: { where: { jti: string } }) =>
+      where.jti === jti
+        ? record
+        : where.jti === successorJti
+          ? successor
+          : null,
+  );
+  const prisma = createPrisma(transaction);
+  const service = new AuthSessionService(prisma as never, {
+    ...DEFAULT_AUTH_TIMING,
+    refreshReuseGraceSeconds:
+      options.graceSeconds ?? DEFAULT_AUTH_TIMING.refreshReuseGraceSeconds,
+  });
+  return { service, transaction, rawToken, jti, successorJti, sid };
 }
 
 describe('AuthSessionService', () => {
@@ -342,6 +417,96 @@ describe('AuthSessionService', () => {
     expect(transaction.refreshTokenRecord.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({ data: { revokedAt: NOW } }),
     );
+  });
+
+  it('forgives a lost-response retry inside the grace window with an unused successor', async () => {
+    const { service, transaction, rawToken, jti, successorJti, sid } =
+      setupGraceScenario({
+        usedAt: new Date(NOW.getTime() - 1000),
+        successor: {
+          usedAt: null,
+          revokedAt: null,
+          expiresAt: new Date(NOW.getTime() + 30 * 60 * 1000),
+        },
+      });
+
+    const response = await service.rotateRefreshToken(rawToken);
+    const replacement = tokenPayload(response.refreshToken);
+
+    expect(replacement.sid).toBe(sid);
+    expect(replacement.jti).not.toBe(jti);
+    expect(replacement.jti).not.toBe(successorJti);
+    // The session is never revoked — family revocation goes through updateMany.
+    expect(transaction.authSession.updateMany).not.toHaveBeenCalled();
+    // Only the never-received successor is revoked, and the chain extends to the
+    // fresh token, so exactly one live refresh token survives.
+    expect(transaction.refreshTokenRecord.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { jti: successorJti },
+        data: { revokedAt: NOW, replacedByJti: replacement.jti },
+      }),
+    );
+    expect(transaction.refreshTokenRecord.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ jti: replacement.jti, sessionId: sid }),
+    });
+  });
+
+  it('treats an already-used successor as genuine reuse and revokes the family', async () => {
+    const { service, transaction, rawToken } = setupGraceScenario({
+      usedAt: new Date(NOW.getTime() - 1000),
+      successor: {
+        usedAt: new Date(NOW.getTime() - 500),
+        revokedAt: null,
+        expiresAt: new Date(NOW.getTime() + 30 * 60 * 1000),
+      },
+    });
+
+    await expect(service.rotateRefreshToken(rawToken)).rejects.toMatchObject({
+      code: 'AUTH_REFRESH_INVALID',
+      statusCode: 401,
+    });
+    expect(transaction.authSession.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'REVOKED', revokedAt: NOW } }),
+    );
+    expect(transaction.refreshTokenRecord.create).not.toHaveBeenCalled();
+  });
+
+  it('revokes the family when the used token is presented after the grace window', async () => {
+    const { service, transaction, rawToken } = setupGraceScenario({
+      usedAt: new Date(NOW.getTime() - 120_000),
+      successor: {
+        usedAt: null,
+        revokedAt: null,
+        expiresAt: new Date(NOW.getTime() + 30 * 60 * 1000),
+      },
+    });
+
+    await expect(service.rotateRefreshToken(rawToken)).rejects.toMatchObject({
+      code: 'AUTH_REFRESH_INVALID',
+    });
+    expect(transaction.authSession.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'REVOKED', revokedAt: NOW } }),
+    );
+  });
+
+  it('revokes the family on any reuse when the grace window is disabled', async () => {
+    const { service, transaction, rawToken } = setupGraceScenario({
+      usedAt: new Date(NOW.getTime() - 100),
+      successor: {
+        usedAt: null,
+        revokedAt: null,
+        expiresAt: new Date(NOW.getTime() + 30 * 60 * 1000),
+      },
+      graceSeconds: 0,
+    });
+
+    await expect(service.rotateRefreshToken(rawToken)).rejects.toMatchObject({
+      code: 'AUTH_REFRESH_INVALID',
+    });
+    expect(transaction.authSession.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'REVOKED', revokedAt: NOW } }),
+    );
+    expect(transaction.refreshTokenRecord.create).not.toHaveBeenCalled();
   });
 
   it('does not revoke a family for a digest mismatch', async () => {

--- a/RythmRun_backend_nodejs/src/services/auth-session.service.ts
+++ b/RythmRun_backend_nodejs/src/services/auth-session.service.ts
@@ -233,6 +233,72 @@ export class AuthSessionService {
         }
 
         if (record.usedAt !== null) {
+          // A used token was re-presented. This is either a lost-response retry
+          // (the client never received the rotated pair and retries with the old
+          // token) or genuine reuse (theft/replay). Only the retry is forgiven,
+          // and only inside a short window while the successor is still unused.
+          const graceMs = this.authTiming.refreshReuseGraceSeconds * 1000;
+          const withinGrace =
+            graceMs > 0 && now.getTime() - record.usedAt.getTime() <= graceMs;
+          const successorJti = record.replacedByJti;
+
+          if (
+            withinGrace &&
+            successorJti !== null &&
+            record.session.status === 'ACTIVE' &&
+            record.session.revokedAt === null &&
+            record.session.expiresAt > now
+          ) {
+            const successor = await transaction.refreshTokenRecord.findUnique({
+              where: { jti: successorJti },
+            });
+            // An unused successor proves the client never received it. If it was
+            // already used, the client did get the rotated pair, so presenting
+            // the old token is genuine reuse — fall through to family revocation.
+            if (
+              successor !== null &&
+              successor.usedAt === null &&
+              successor.revokedAt === null &&
+              successor.expiresAt > now
+            ) {
+              const tokenPair = this.createTokenPair(
+                record.session.userId,
+                record.session.id,
+                record.session.expiresAt,
+                now,
+              );
+              await transaction.authSession.update({
+                where: { id: record.session.id },
+                data: { lastUsedAt: now },
+              });
+              await transaction.refreshTokenRecord.create({
+                data: {
+                  jti: tokenPair.refreshJti,
+                  sessionId: record.session.id,
+                  tokenDigest: tokenPair.refreshDigest,
+                  issuedAt: now,
+                  expiresAt: record.session.expiresAt,
+                },
+              });
+              // Revoke the never-received successor and extend the chain to the
+              // fresh token, so exactly one live refresh token survives.
+              await transaction.refreshTokenRecord.update({
+                where: { jti: successor.jti },
+                data: { revokedAt: now, replacedByJti: tokenPair.refreshJti },
+              });
+              return {
+                kind: 'success',
+                response: {
+                  ...toSafeUserResponse(record.session.user),
+                  accessToken: tokenPair.accessToken,
+                  refreshToken: tokenPair.refreshToken,
+                },
+              };
+            }
+          }
+
+          // Genuine reuse (grace disabled, window passed, or successor already
+          // spent): kill the whole family so a stolen token cannot rotate.
           if (
             record.session.status === 'ACTIVE' &&
             record.session.revokedAt === null

--- a/docs/_engineering/auth-hardening/MASTER-PLAN.md
+++ b/docs/_engineering/auth-hardening/MASTER-PLAN.md
@@ -4,7 +4,7 @@ published: false
 
 # Auth Hardening & Tunable Timing — Master Plan
 
-**Status:** Phase 0 merged · Phase 1 complete — awaiting review · **Owner:** maintainer · **Created:** 2026-08-11
+**Status:** Phases 0–1 merged · Phase 2 complete — awaiting review · **Owner:** maintainer · **Created:** 2026-08-11
 **Source:** auth + refresh audit (16 confirmed findings, 1 plausible, 2 refuted)
 **Relationship to the improvement program:** this is IP-2 follow-up work. It does
 not replace `IP-2-auth-account-privacy.md`; when a phase here lands, its evidence
@@ -634,9 +634,9 @@ Legend: `[ ]` pending · `[~]` in progress · `[x]` done
 - [x] Tests: sweep drains the outbox (server-bootstrap); 6th deletion re-auth in an hour → `429` (api-abuse-controls)
 
 ### Phase 2 — Refresh grace window
-- [ ] **M1** grace branch in `rotateRefreshToken`
-- [ ] Four rotation tests (grace / used successor / expired window / strict mode)
-- [ ] Real-device airplane-mode proof
+- [x] **M1** grace branch in `rotateRefreshToken` (revoke successor only + mint fresh pair on a lost-response retry; else kill the family)
+- [x] Four rotation tests (grace / used successor / expired window / strict mode) — unit, all passing
+- [~] Real-device airplane-mode proof is a maintainer deploy check (use `ACCESS_TOKEN_TTL_SECONDS=30`)
 
 ### Phase 3 — Client credential simplification
 - [ ] **3a** legacy migration + `requiresServerVerification` deleted (43 refs, 5 files)
@@ -698,7 +698,9 @@ Flutter 359 passed · analyzer 9 issues, 0 warnings, 0 errors. (The prior
 `464 / 7 / 471` figure was stale — the Phase 0 lock-baseline step measured the
 true starting point. Phase 0 adds config-spine tests, taking the backend to
 507 passed / 7 skipped / 514 total with Flutter unchanged at 359. Phase 1 adds
-the M5 sweep and M3 rate-limit tests → 508 passed / 7 skipped / 515 total.)
+the M5 sweep and M3 rate-limit tests → 508 passed / 7 skipped / 515 total.
+Phase 2 adds four grace-window rotation tests → 512 passed / 7 skipped / 519
+total.)
 
 **Four known traps** (from `CLAUDE.md`, repeated because they cost real time):
 1. Use `npm test`, never `npx jest` — the suite is native ESM.


### PR DESCRIPTION
… (Phase 2)

M1 — a refresh rotation whose response never reached the client left the client holding the old (now consumed) token. Re-presenting it was treated as token reuse and killed the whole session, so a single dropped refresh response forced a full re-login. Common on flaky mobile networks.

rotateRefreshToken now distinguishes the two cases at the "already used" check:

- Lost-response retry: within REFRESH_REUSE_GRACE_SECONDS of consumption AND the successor is still unused/unrevoked/unexpired -> revoke only that successor and mint a fresh pair on the same session, extending the chain. Exactly one live refresh token survives; the session stays ACTIVE.
- Genuine reuse: successor already spent, window passed, or grace disabled (REFRESH_REUSE_GRACE_SECONDS=0) -> revoke the entire session, unchanged.

An unused successor is the tell: had the client received the rotated pair it would have spent the successor, so an unused successor means the response was lost. Reuses Phase 0's REFRESH_REUSE_GRACE_SECONDS knob (default 60s; 0 tests the theft path).

Tests: four rotation cases (grace success keeps the session and revokes only the successor; used successor -> family revoked; presented after the window -> family revoked; grace disabled -> family revoked). Backend 512 passed / 7 skipped / 519 total; build + smoke green.