### PR TITLE
refactor(auth): delete legacy-token migration and requiresServerVerif…

### DIFF
--- a/docs/_engineering/auth-hardening/MASTER-PLAN.md
+++ b/docs/_engineering/auth-hardening/MASTER-PLAN.md
@@ -4,7 +4,7 @@ published: false
 
 # Auth Hardening & Tunable Timing — Master Plan
 
-**Status:** Phases 0–1 merged · Phase 2 complete — awaiting review · **Owner:** maintainer · **Created:** 2026-08-11
+**Status:** Phases 0–2 done · Phase 3a complete — awaiting review · **Owner:** maintainer · **Created:** 2026-08-11
 **Source:** auth + refresh audit (16 confirmed findings, 1 plausible, 2 refuted)
 **Relationship to the improvement program:** this is IP-2 follow-up work. It does
 not replace `IP-2-auth-account-privacy.md`; when a phase here lands, its evidence
@@ -639,8 +639,8 @@ Legend: `[ ]` pending · `[~]` in progress · `[x]` done
 - [~] Real-device airplane-mode proof is a maintainer deploy check (use `ACCESS_TOKEN_TTL_SECONDS=30`)
 
 ### Phase 3 — Client credential simplification
-- [ ] **3a** legacy migration + `requiresServerVerification` deleted (43 refs, 5 files)
-- [ ] **3a** dead legacy-migration tests removed; suite still green
+- [x] **3a** legacy migration + `requiresServerVerification` / `markServerVerified` deleted across 5 lib files (net −854 lines). Kept a simplified gate-protected `markCurrentCredentialsServerVerified` — its only surviving job is the sync-timer reset, not a verification stamp.
+- [x] **3a** dead legacy-migration + verification-stamp tests removed (15 tests); suite green at 344, analyzer 9
 - [ ] **M2** same-session rotation accepted (on simplified coordinator)
 - [ ] **A3** failed flights evicted
 - [ ] **A4** avatar replay policy
@@ -700,7 +700,8 @@ true starting point. Phase 0 adds config-spine tests, taking the backend to
 507 passed / 7 skipped / 514 total with Flutter unchanged at 359. Phase 1 adds
 the M5 sweep and M3 rate-limit tests → 508 passed / 7 skipped / 515 total.
 Phase 2 adds four grace-window rotation tests → 512 passed / 7 skipped / 519
-total.)
+total. Phase 3a is client-only and **deliberately drops** the Flutter count from
+359 to 344 by deleting 15 dead legacy-migration / verification-stamp tests.)
 
 **Four known traps** (from `CLAUDE.md`, repeated because they cost real time):
 1. Use `npm test`, never `npx jest` — the suite is native ESM.

--- a/rythmrun_frontend_flutter/lib/core/network/authenticated_request_coordinator.dart
+++ b/rythmrun_frontend_flutter/lib/core/network/authenticated_request_coordinator.dart
@@ -143,10 +143,9 @@ class AuthenticatedRequestCoordinator implements AuthenticatedRequestExecutor {
     }
   }
 
-  /// Commits a successful server verification under the authentication gate.
-  ///
-  /// This keeps the verification timestamp from being written back after an
-  /// account exit has drained the gate and cleared local authentication data.
+  /// Commits a successful online verification under the authentication gate by
+  /// resetting the backend-sync timer. The gate keeps this from running after an
+  /// account exit has drained it and cleared local authentication data.
   Future<void> markCurrentCredentialsServerVerified() async {
     final lease = _authenticationAttemptGate.tryAcquire();
     if (lease == null) {
@@ -156,10 +155,6 @@ class AuthenticatedRequestCoordinator implements AuthenticatedRequestExecutor {
     }
 
     try {
-      final snapshot = await _readRequiredSnapshot();
-      if (snapshot.requiresServerVerification) {
-        await _markMigratedSnapshotVerified(snapshot);
-      }
       await _commitServerVerificationSafely();
     } finally {
       lease.release();
@@ -349,19 +344,6 @@ class AuthenticatedRequestCoordinator implements AuthenticatedRequestExecutor {
       return await _credentialVault.compareAndSetCredentials(
         expectedRevision: expectedRevision,
         replacement: replacement,
-        requiresServerVerification: false,
-      );
-    } catch (_) {
-      throw const AuthSessionUnavailable(
-        AuthSessionUnavailableReason.credentialStoreUnavailable,
-      );
-    }
-  }
-
-  Future<AuthCredentialSnapshot?> _markServerVerified(int revision) async {
-    try {
-      return await _credentialVault.markCredentialsServerVerified(
-        expectedRevision: revision,
       );
     } catch (_) {
       throw const AuthSessionUnavailable(
@@ -394,39 +376,7 @@ class AuthenticatedRequestCoordinator implements AuthenticatedRequestExecutor {
     AuthCredentialSnapshot expected,
   ) async {
     final current = await _readSnapshot();
-    if (_sameCredentials(current, expected)) {
-      if (!expected.requiresServerVerification) return;
-      await _markMigratedSnapshotVerified(expected);
-      return;
-    }
-
-    // Concurrent first requests can both prove the same migrated pair. The
-    // first CAS increments the envelope revision; the second accepts that
-    // already-verified state only when the token pair is still identical.
-    if (expected.requiresServerVerification &&
-        current != null &&
-        current.pair == expected.pair &&
-        !current.requiresServerVerification) {
-      return;
-    }
-
-    throw const AuthSessionUnavailable(
-      AuthSessionUnavailableReason.credentialsChanged,
-    );
-  }
-
-  Future<void> _markMigratedSnapshotVerified(
-    AuthCredentialSnapshot expected,
-  ) async {
-    final verified = await _markServerVerified(expected.revision);
-    if (verified != null) return;
-
-    final current = await _readSnapshot();
-    if (current != null &&
-        current.pair == expected.pair &&
-        !current.requiresServerVerification) {
-      return;
-    }
+    if (_sameCredentials(current, expected)) return;
 
     throw const AuthSessionUnavailable(
       AuthSessionUnavailableReason.credentialsChanged,

--- a/rythmrun_frontend_flutter/lib/core/services/auth_persistence_service.dart
+++ b/rythmrun_frontend_flutter/lib/core/services/auth_persistence_service.dart
@@ -9,8 +9,7 @@ import '../../domain/entities/user_entity.dart';
 import 'auth_token_store.dart';
 
 /// Narrow preference seam. Authentication credentials must never be written
-/// through this interface; it exists only for non-secret account metadata and
-/// safe migration from the two historical preference keys.
+/// through this interface; it exists only for non-secret account metadata.
 abstract interface class AuthPreferences {
   String? getString(String key);
 
@@ -79,8 +78,6 @@ class AuthPersistenceService {
            )),
        _now = now ?? DateTime.now;
 
-  static const String legacyAccessTokenKey = 'access_token';
-  static const String legacyRefreshTokenKey = 'refresh_token';
   static const String userDataKey = 'user_data';
   static const String lastBackendSyncKey = 'last_backend_sync';
   static const String authCleanupPendingKey = 'auth_cleanup_pending';
@@ -119,53 +116,26 @@ class AuthPersistenceService {
     defaultValue: 168,
   );
 
-  static final RegExp _uuidPattern = RegExp(
-    r'^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
-    caseSensitive: false,
-  );
-
   final AuthTokenStore _tokenStore;
   final AuthPreferencesFactory _preferencesFactory;
   final DateTime Function() _now;
 
-  Future<AuthCredentialSnapshot?>? _migrationInFlight;
-  Future<void> _credentialLifecycleTail = Future<void>.value();
-  bool _migrationSettled = false;
-
-  Future<AuthCredentialSnapshot?> readCredentialSnapshot() async {
-    if (!_migrationSettled) return _ensureLegacyMigration();
+  Future<AuthCredentialSnapshot?> readCredentialSnapshot() {
     return _tokenStore.read();
   }
 
-  Future<AuthCredentialSnapshot> replaceCredentials(
-    AuthTokenPair replacement, {
-    bool requiresServerVerification = false,
-  }) async {
-    await _ensureLegacyMigration();
-    return _tokenStore.write(
-      replacement,
-      requiresServerVerification: requiresServerVerification,
-    );
+  Future<AuthCredentialSnapshot> replaceCredentials(AuthTokenPair replacement) {
+    return _tokenStore.write(replacement);
   }
 
   Future<AuthCredentialSnapshot?> compareAndSetCredentials({
     required int expectedRevision,
     required AuthTokenPair replacement,
-    bool requiresServerVerification = false,
-  }) async {
-    await _ensureLegacyMigration();
+  }) {
     return _tokenStore.compareAndSet(
       expectedRevision: expectedRevision,
       replacement: replacement,
-      requiresServerVerification: requiresServerVerification,
     );
-  }
-
-  Future<AuthCredentialSnapshot?> markCredentialsServerVerified({
-    required int expectedRevision,
-  }) async {
-    await _ensureLegacyMigration();
-    return _tokenStore.markServerVerified(expectedRevision: expectedRevision);
   }
 
   Future<void> saveAuthData(AuthResponseModel authResponse) async {
@@ -254,32 +224,16 @@ class AuthPersistenceService {
   }
 
   Future<void> clearCredentials() async {
-    // Prevent a new legacy migration from starting. The shared FIFO guarantees
-    // that an already-started migration finishes before this final delete, or
-    // that a clear which started first removes legacy values before any later
-    // read can consider migrating them.
-    _migrationSettled = true;
-    await _serializeCredentialLifecycle(_clearCredentialsUnsafe);
-  }
-
-  Future<void> _clearCredentialsUnsafe() async {
+    // The secure store serializes its own delete/read, so no extra FIFO is
+    // needed here now that legacy migration is gone.
     await _tokenStore.delete();
-    final preferences = await _preferencesFactory();
-    await _removeLegacyCredentials(preferences);
     if (await _tokenStore.read() != null) {
       throw StateError('Secure authentication credentials remain.');
     }
   }
 
-  Future<bool> clearCredentialsIfRevision(int expectedRevision) async {
-    await _ensureLegacyMigration();
-    final deleted = await _tokenStore.deleteIfRevision(expectedRevision);
-    if (!deleted) return false;
-
-    final preferences = await _preferencesFactory();
-    await _removeLegacyCredentials(preferences);
-    _migrationSettled = true;
-    return true;
+  Future<bool> clearCredentialsIfRevision(int expectedRevision) {
+    return _tokenStore.deleteIfRevision(expectedRevision);
   }
 
   Future<void> clearAuthData() async {
@@ -292,8 +246,6 @@ class AuthPersistenceService {
 
     if (preferences.containsKey(userDataKey) ||
         preferences.containsKey(lastBackendSyncKey) ||
-        preferences.containsKey(legacyAccessTokenKey) ||
-        preferences.containsKey(legacyRefreshTokenKey) ||
         await _tokenStore.read() != null) {
       throw StateError('Locally persisted authentication data remains.');
     }
@@ -364,7 +316,7 @@ class AuthPersistenceService {
   /// value, so a subsequent clock rollback below it is detectable.
   Future<bool> canStayLoggedInOffline() async {
     final snapshot = await readCredentialSnapshot();
-    if (snapshot == null || snapshot.requiresServerVerification) return false;
+    if (snapshot == null) return false;
     if (await getUserData() == null) return false;
     try {
       if (JwtDecoder.isExpired(snapshot.pair.refreshToken)) return false;
@@ -387,8 +339,8 @@ class AuthPersistenceService {
   bool _isWithinVerifiedOfflineWindow(AuthCredentialSnapshot snapshot) {
     final verifiedAtMs = snapshot.lastVerifiedAtMs;
     // A pair with no integrity-sensitive verification anchor (a pre-IP-2.3
-    // envelope or a never-verified migration) cannot enter offline mode until
-    // one online verification stamps it. Completed local data is not deleted.
+    // envelope) cannot enter offline mode until one online verification stamps
+    // it. Completed local data is not deleted.
     if (verifiedAtMs == null) return false;
 
     final nowMs = _now().millisecondsSinceEpoch;
@@ -407,170 +359,6 @@ class AuthPersistenceService {
 
     // Bounded seven-day window from the last integrity-checked verification.
     return nowMs - verifiedAtMs <= offlineWindow.inMilliseconds;
-  }
-
-  Future<AuthCredentialSnapshot?> _ensureLegacyMigration() {
-    final existing = _migrationInFlight;
-    if (existing != null) return existing;
-    if (_migrationSettled) return _tokenStore.read();
-
-    late final Future<AuthCredentialSnapshot?> operation;
-    operation = _serializeCredentialLifecycle(
-      _migrateLegacyCredentials,
-    ).whenComplete(() {
-      if (identical(_migrationInFlight, operation)) {
-        _migrationInFlight = null;
-      }
-    });
-    _migrationInFlight = operation;
-    return operation;
-  }
-
-  Future<T> _serializeCredentialLifecycle<T>(Future<T> Function() operation) {
-    final completer = Completer<T>();
-    _credentialLifecycleTail = _credentialLifecycleTail.then((_) async {
-      try {
-        completer.complete(await operation());
-      } catch (error, stackTrace) {
-        completer.completeError(error, stackTrace);
-      }
-    });
-    return completer.future;
-  }
-
-  Future<AuthCredentialSnapshot?> _migrateLegacyCredentials() async {
-    final preferences = await _preferencesFactory();
-    final secureSnapshot = await _tokenStore.read();
-
-    if (secureSnapshot != null) {
-      // A verified secure write always wins. This is also the retry path for a
-      // process interrupted after secure write but before preference cleanup.
-      await _removeLegacyCredentials(preferences);
-      _migrationSettled = true;
-      return secureSnapshot;
-    }
-
-    final accessToken = preferences.getString(legacyAccessTokenKey);
-    final refreshToken = preferences.getString(legacyRefreshTokenKey);
-    if (accessToken == null && refreshToken == null) {
-      _migrationSettled = true;
-      return null;
-    }
-
-    final userId = _storedUserId(preferences.getString(userDataKey));
-    if (accessToken == null ||
-        refreshToken == null ||
-        !_isCoherentIp21Pair(accessToken, refreshToken, userId: userId)) {
-      // An incomplete, malformed, expired, or pre-IP-2.1 pair cannot be used.
-      // Remove it from plaintext preferences and fail closed.
-      await _removeLegacyCredentials(preferences);
-      _migrationSettled = true;
-      return null;
-    }
-
-    final migrated = await _tokenStore.write(
-      AuthTokenPair(accessToken: accessToken, refreshToken: refreshToken),
-      requiresServerVerification: true,
-    );
-    final readBack = await _tokenStore.read();
-    if (readBack == null ||
-        readBack.revision != migrated.revision ||
-        readBack.pair != migrated.pair ||
-        !readBack.requiresServerVerification) {
-      throw StateError('Secure credential migration could not be verified.');
-    }
-
-    // Plaintext is removed only after the complete secure envelope is read
-    // back. Any failure here leaves the remaining key for a safe retry.
-    await _removeLegacyCredentials(preferences);
-    _migrationSettled = true;
-    return readBack;
-  }
-
-  String? _storedUserId(String? encodedUser) {
-    if (encodedUser == null) return null;
-    try {
-      final decoded = jsonDecode(encodedUser);
-      if (decoded is! Map<String, dynamic>) return null;
-      final id = decoded['id'];
-      return id is String ? id : null;
-    } catch (_) {
-      return null;
-    }
-  }
-
-  bool _isCoherentIp21Pair(
-    String accessToken,
-    String refreshToken, {
-    String? userId,
-  }) {
-    final access = _decodeJwt(accessToken);
-    final refresh = _decodeJwt(refreshToken);
-    if (access == null || refresh == null) return false;
-
-    final accessSubject = access['sub'];
-    final refreshSubject = refresh['sub'];
-    final accessSession = access['sid'];
-    final refreshSession = refresh['sid'];
-    final accessJti = access['jti'];
-    final refreshJti = refresh['jti'];
-    final accessIssuedAt = access['iat'];
-    final refreshIssuedAt = refresh['iat'];
-    final accessExpiresAt = access['exp'];
-    final refreshExpiresAt = refresh['exp'];
-
-    if (accessSubject is! String ||
-        int.tryParse(accessSubject)?.toString() != accessSubject ||
-        int.parse(accessSubject) <= 0 ||
-        refreshSubject != accessSubject ||
-        (userId != null && userId != accessSubject) ||
-        access['typ'] != 'access' ||
-        refresh['typ'] != 'refresh' ||
-        accessSession is! String ||
-        !_uuidPattern.hasMatch(accessSession) ||
-        refreshSession != accessSession ||
-        accessJti is! String ||
-        !_uuidPattern.hasMatch(accessJti) ||
-        refreshJti is! String ||
-        !_uuidPattern.hasMatch(refreshJti) ||
-        refreshJti == accessJti ||
-        accessIssuedAt is! int ||
-        refreshIssuedAt != accessIssuedAt ||
-        accessExpiresAt is! int ||
-        refreshExpiresAt is! int ||
-        accessExpiresAt <= accessIssuedAt ||
-        refreshExpiresAt <= refreshIssuedAt ||
-        accessExpiresAt > refreshExpiresAt ||
-        refreshExpiresAt <= _now().millisecondsSinceEpoch ~/ 1000) {
-      return false;
-    }
-    return true;
-  }
-
-  Map<String, dynamic>? _decodeJwt(String token) {
-    try {
-      final parts = token.split('.');
-      if (parts.length != 3 || parts.any((part) => part.isEmpty)) return null;
-      final header = jsonDecode(
-        utf8.decode(base64Url.decode(base64Url.normalize(parts[0]))),
-      );
-      final payload = jsonDecode(
-        utf8.decode(base64Url.decode(base64Url.normalize(parts[1]))),
-      );
-      if (header is! Map<String, dynamic> ||
-          header['alg'] != 'HS256' ||
-          payload is! Map<String, dynamic>) {
-        return null;
-      }
-      return payload;
-    } catch (_) {
-      return null;
-    }
-  }
-
-  Future<void> _removeLegacyCredentials(AuthPreferences preferences) async {
-    await _removePreference(preferences, legacyAccessTokenKey);
-    await _removePreference(preferences, legacyRefreshTokenKey);
   }
 
   Future<void> _writeString(

--- a/rythmrun_frontend_flutter/lib/core/services/auth_token_store.dart
+++ b/rythmrun_frontend_flutter/lib/core/services/auth_token_store.dart
@@ -35,28 +35,23 @@ final class AuthTokenPair {
 /// A coherent credential snapshot read from the secure store.
 ///
 /// [revision] is an opaque compare-and-set generation for refresh rotation.
-/// A migrated legacy pair requires a backend check before it is eligible for
-/// normal offline admission.
 ///
 /// [lastVerifiedAtMs] and [maxObservedAtMs] are integrity-sensitive session
 /// metadata used by the offline-admission policy (IP-2.3). They travel inside
 /// the same secure envelope as the credentials, are never client-writable in
 /// plaintext preferences, and default to `null` for an envelope written before
-/// IP-2.3 or for a migrated-but-unverified pair. `null` [lastVerifiedAtMs]
-/// means "never server-verified since IP-2.3" and fails closed on offline
-/// admission until an online verification stamps it.
+/// IP-2.3. `null` [lastVerifiedAtMs] means "never server-verified since IP-2.3"
+/// and fails closed on offline admission until an online verification stamps it.
 final class AuthCredentialSnapshot {
   const AuthCredentialSnapshot({
     required this.pair,
     required this.revision,
-    required this.requiresServerVerification,
     this.lastVerifiedAtMs,
     this.maxObservedAtMs,
   });
 
   final AuthTokenPair pair;
   final int revision;
-  final bool requiresServerVerification;
 
   /// Epoch milliseconds of the last successful server verification of this
   /// credential pair (login, refresh rotation, or `/me`). The offline window
@@ -75,7 +70,6 @@ final class AuthCredentialSnapshot {
   String toString() {
     return 'AuthCredentialSnapshot('
         'revision: $revision, '
-        'requiresServerVerification: $requiresServerVerification, '
         'lastVerifiedAtMs: $lastVerifiedAtMs, '
         'maxObservedAtMs: $maxObservedAtMs, '
         'credentials: <redacted>)';
@@ -92,11 +86,6 @@ abstract interface class AuthCredentialVault {
   Future<AuthCredentialSnapshot?> compareAndSetCredentials({
     required int expectedRevision,
     required AuthTokenPair replacement,
-    bool requiresServerVerification = false,
-  });
-
-  Future<AuthCredentialSnapshot?> markCredentialsServerVerified({
-    required int expectedRevision,
   });
 }
 
@@ -115,19 +104,11 @@ abstract interface class RejectedCredentialQuarantine {
 abstract interface class AuthTokenStore {
   Future<AuthCredentialSnapshot?> read();
 
-  Future<AuthCredentialSnapshot> write(
-    AuthTokenPair pair, {
-    bool requiresServerVerification = false,
-  });
+  Future<AuthCredentialSnapshot> write(AuthTokenPair pair);
 
   Future<AuthCredentialSnapshot?> compareAndSet({
     required int expectedRevision,
     required AuthTokenPair replacement,
-    bool requiresServerVerification = false,
-  });
-
-  Future<AuthCredentialSnapshot?> markServerVerified({
-    required int expectedRevision,
   });
 
   /// Records the current wall clock as the observed high-water mark without
@@ -220,23 +201,19 @@ final class SecureAuthTokenStore implements AuthTokenStore {
   }
 
   @override
-  Future<AuthCredentialSnapshot> write(
-    AuthTokenPair pair, {
-    bool requiresServerVerification = false,
-  }) {
+  Future<AuthCredentialSnapshot> write(AuthTokenPair pair) {
     return _exclusive(() async {
       final current = await _readUnsafe();
       final nowMs = _nowMs();
       return _writeUnsafe(
         pair,
         revision: _nextRevision(current),
-        requiresServerVerification: requiresServerVerification,
-        // A fresh non-migrated write is a direct backend authentication, so it
-        // anchors the verified time. A migrated pair is not yet verified.
-        lastVerifiedAtMs: requiresServerVerification ? null : nowMs,
-        // Establishing a new credential is a trusted reference point, so the
-        // observed high-water mark resets to now. This prevents a prior forward
-        // clock excursion from permanently poisoning the rollback tripwire.
+        // A fresh write is a direct backend authentication, so it anchors the
+        // verified time. Establishing a new credential is also a trusted
+        // reference point, so the observed high-water mark resets to now — this
+        // prevents a prior forward clock excursion from permanently poisoning
+        // the rollback tripwire.
+        lastVerifiedAtMs: nowMs,
         maxObservedAtMs: nowMs,
       );
     });
@@ -246,7 +223,6 @@ final class SecureAuthTokenStore implements AuthTokenStore {
   Future<AuthCredentialSnapshot?> compareAndSet({
     required int expectedRevision,
     required AuthTokenPair replacement,
-    bool requiresServerVerification = false,
   }) {
     return _exclusive(() async {
       final current = await _readUnsafe();
@@ -256,34 +232,8 @@ final class SecureAuthTokenStore implements AuthTokenStore {
       return _writeUnsafe(
         replacement,
         revision: _nextRevision(current),
-        requiresServerVerification: requiresServerVerification,
         // A successful refresh rotation is a backend verification of identity,
         // so it re-anchors both the verified time and the trusted observed mark.
-        lastVerifiedAtMs: requiresServerVerification ? null : nowMs,
-        maxObservedAtMs: nowMs,
-      );
-    });
-  }
-
-  @override
-  Future<AuthCredentialSnapshot?> markServerVerified({
-    required int expectedRevision,
-  }) {
-    return _exclusive(() async {
-      final current = await _readUnsafe();
-      if (current?.revision != expectedRevision) return null;
-
-      final nowMs = _nowMs();
-      return _writeUnsafe(
-        current!.pair,
-        // Revision identifies the credential pair, not envelope metadata. A
-        // verification-only write must not make an in-flight refresh CAS look
-        // stale after the backend has already consumed its refresh token.
-        revision: current.revision,
-        requiresServerVerification: false,
-        // A successful `/me` or first authenticated request re-anchors the
-        // verified time and the trusted observed mark even when the pair was
-        // already verified, recovering from any prior forward clock excursion.
         lastVerifiedAtMs: nowMs,
         maxObservedAtMs: nowMs,
       );
@@ -302,7 +252,6 @@ final class SecureAuthTokenStore implements AuthTokenStore {
       return _writeUnsafe(
         current.pair,
         revision: current.revision,
-        requiresServerVerification: current.requiresServerVerification,
         lastVerifiedAtMs: current.lastVerifiedAtMs,
         maxObservedAtMs: advanced,
       );
@@ -340,7 +289,6 @@ final class SecureAuthTokenStore implements AuthTokenStore {
       if (decoded is! Map<String, dynamic> ||
           decoded['version'] != _envelopeVersion ||
           decoded['revision'] is! int ||
-          decoded['requiresServerVerification'] is! bool ||
           decoded['accessToken'] is! String ||
           decoded['refreshToken'] is! String) {
         throw const CredentialStoreCorruptedException();
@@ -360,8 +308,6 @@ final class SecureAuthTokenStore implements AuthTokenStore {
       return AuthCredentialSnapshot(
         pair: pair,
         revision: revision,
-        requiresServerVerification:
-            decoded['requiresServerVerification'] as bool,
         // Session metadata is optional and forgiving: a value absent from a
         // pre-IP-2.3 envelope, or present but malformed, reads back as null.
         // That fails offline admission closed rather than corrupting the whole
@@ -392,14 +338,12 @@ final class SecureAuthTokenStore implements AuthTokenStore {
   Future<AuthCredentialSnapshot> _writeUnsafe(
     AuthTokenPair pair, {
     required int revision,
-    required bool requiresServerVerification,
     required int? lastVerifiedAtMs,
     required int? maxObservedAtMs,
   }) async {
     final envelope = <String, Object>{
       'version': _envelopeVersion,
       'revision': revision,
-      'requiresServerVerification': requiresServerVerification,
       'accessToken': pair.accessToken,
       'refreshToken': pair.refreshToken,
     };
@@ -419,7 +363,6 @@ final class SecureAuthTokenStore implements AuthTokenStore {
     return AuthCredentialSnapshot(
       pair: pair,
       revision: revision,
-      requiresServerVerification: requiresServerVerification,
       lastVerifiedAtMs: lastVerifiedAtMs,
       maxObservedAtMs: maxObservedAtMs,
     );

--- a/rythmrun_frontend_flutter/lib/data/datasources/auth_local_datasource.dart
+++ b/rythmrun_frontend_flutter/lib/data/datasources/auth_local_datasource.dart
@@ -24,35 +24,18 @@ class AuthLocalDataSource
     return _persistenceService.readCredentialSnapshot();
   }
 
-  Future<AuthCredentialSnapshot> replaceCredentials(
-    AuthTokenPair replacement, {
-    bool requiresServerVerification = false,
-  }) {
-    return _persistenceService.replaceCredentials(
-      replacement,
-      requiresServerVerification: requiresServerVerification,
-    );
+  Future<AuthCredentialSnapshot> replaceCredentials(AuthTokenPair replacement) {
+    return _persistenceService.replaceCredentials(replacement);
   }
 
   @override
   Future<AuthCredentialSnapshot?> compareAndSetCredentials({
     required int expectedRevision,
     required AuthTokenPair replacement,
-    bool requiresServerVerification = false,
   }) {
     return _persistenceService.compareAndSetCredentials(
       expectedRevision: expectedRevision,
       replacement: replacement,
-      requiresServerVerification: requiresServerVerification,
-    );
-  }
-
-  @override
-  Future<AuthCredentialSnapshot?> markCredentialsServerVerified({
-    required int expectedRevision,
-  }) {
-    return _persistenceService.markCredentialsServerVerified(
-      expectedRevision: expectedRevision,
     );
   }
 

--- a/rythmrun_frontend_flutter/lib/data/repositories/auth_repository_impl.dart
+++ b/rythmrun_frontend_flutter/lib/data/repositories/auth_repository_impl.dart
@@ -259,9 +259,7 @@ class AuthRepositoryImpl implements AuthRepository {
     if (credentialSnapshot == null) {
       return SessionValidationStatus.invalid;
     }
-    final requiresServerCheck =
-        credentialSnapshot.requiresServerVerification ||
-        await _localDataSource.needsBackendSync();
+    final requiresServerCheck = await _localDataSource.needsBackendSync();
 
     if (requiresServerCheck) {
       try {

--- a/rythmrun_frontend_flutter/test/core/network/authenticated_request_coordinator_test.dart
+++ b/rythmrun_frontend_flutter/test/core/network/authenticated_request_coordinator_test.dart
@@ -290,85 +290,6 @@ void main() {
   );
 
   test(
-    'verification-only metadata does not make an in-flight refresh stale',
-    () async {
-      vault.current = _snapshot(
-        access: 'migrated-access',
-        refresh: 'migrated-refresh',
-        requiresServerVerification: true,
-      );
-      final refreshStarted = Completer<void>();
-      final finishRefresh = Completer<AuthResponseModel>();
-      remote.onRefresh = (_) {
-        refreshStarted.complete();
-        return finishRefresh.future;
-      };
-      var refreshRequestCalls = 0;
-
-      final refreshingRequest = coordinator.execute<String>(
-        replayPolicy: AuthenticatedReplayPolicy.idempotent,
-        request: (_) async {
-          refreshRequestCalls++;
-          if (refreshRequestCalls == 1) {
-            throw UnauthorizedException(
-              'expired',
-              code: AuthenticatedRequestCoordinator.invalidAccessCode,
-            );
-          }
-          return 'refreshed';
-        },
-      );
-      await refreshStarted.future;
-
-      expect(
-        await coordinator.execute<String>(request: (_) async => 'verified'),
-        'verified',
-      );
-      expect(vault.current!.revision, 1);
-      expect(vault.current!.requiresServerVerification, isFalse);
-
-      finishRefresh.complete(
-        _response(access: 'access-2', refresh: 'refresh-2'),
-      );
-      expect(await refreshingRequest, 'refreshed');
-      expect(vault.current!.pair.accessToken, 'access-2');
-      expect(remote.refreshCalls, 1);
-    },
-  );
-
-  test(
-    'invalid refresh remains invalid after a concurrent verification-only write',
-    () async {
-      vault.current = _snapshot(
-        access: 'migrated-access',
-        refresh: 'migrated-refresh',
-        requiresServerVerification: true,
-      );
-      final refreshStarted = Completer<void>();
-      final finishRefresh = Completer<AuthResponseModel>();
-      remote.onRefresh = (_) {
-        refreshStarted.complete();
-        return finishRefresh.future;
-      };
-
-      final refreshingRequest = _accessRejectedRequest(coordinator);
-      await refreshStarted.future;
-      await coordinator.execute<void>(request: (_) async {});
-      expect(vault.current!.revision, 1);
-
-      finishRefresh.completeError(
-        UnauthorizedException(
-          'rejected',
-          code: AuthenticatedRequestCoordinator.invalidRefreshCode,
-        ),
-      );
-      await expectLater(refreshingRequest, throwsA(isA<AuthSessionInvalid>()));
-      expect(vault.current, isNull);
-      expect(vault.clearIfRevisionCalls, 1);
-    },
-  );
-
-  test(
     'a stale invalid refresh cannot clear a newer credential pair',
     () async {
       final refreshStarted = Completer<void>();
@@ -483,58 +404,6 @@ void main() {
     expect(vault.current!.pair.accessToken, 'access-2');
   });
 
-  test(
-    'successful protected request verifies a migrated pair with CAS',
-    () async {
-      vault.current = _snapshot(
-        access: 'migrated-access',
-        refresh: 'migrated-refresh',
-        requiresServerVerification: true,
-      );
-
-      final result = await coordinator.execute<String>(
-        request: (_) async => 'verified',
-      );
-
-      expect(result, 'verified');
-      expect(vault.markVerifiedCalls, 1);
-      expect(vault.current!.requiresServerVerification, isFalse);
-      expect(vault.current!.revision, 1);
-    },
-  );
-
-  test(
-    'concurrent first requests accept the same pair verified by a peer',
-    () async {
-      vault.current = _snapshot(
-        access: 'migrated-access',
-        refresh: 'migrated-refresh',
-        requiresServerVerification: true,
-      );
-      final releaseRequests = Completer<void>();
-      var enteredRequests = 0;
-
-      Future<String> run(String value) {
-        return coordinator.execute<String>(
-          request: (_) async {
-            enteredRequests++;
-            if (enteredRequests == 2) releaseRequests.complete();
-            await releaseRequests.future;
-            return value;
-          },
-        );
-      }
-
-      final results = await Future.wait(<Future<String>>[
-        run('one'),
-        run('two'),
-      ]);
-
-      expect(results, <String>['one', 'two']);
-      expect(vault.current!.requiresServerVerification, isFalse);
-      expect(vault.current!.pair.accessToken, 'migrated-access');
-    },
-  );
 }
 
 Future<void> _accessRejectedRequest(
@@ -555,12 +424,10 @@ AuthCredentialSnapshot _snapshot({
   required String access,
   required String refresh,
   int revision = 1,
-  bool requiresServerVerification = false,
 }) {
   return AuthCredentialSnapshot(
     pair: AuthTokenPair(accessToken: access, refreshToken: refresh),
     revision: revision,
-    requiresServerVerification: requiresServerVerification,
   );
 }
 
@@ -583,7 +450,6 @@ class _FakeCredentialVault
 
   AuthCredentialSnapshot? current;
   int compareAndSetCalls = 0;
-  int markVerifiedCalls = 0;
   int clearIfRevisionCalls = 0;
   bool failClear = false;
   bool cleanupPending = false;
@@ -595,7 +461,6 @@ class _FakeCredentialVault
   Future<AuthCredentialSnapshot?> compareAndSetCredentials({
     required int expectedRevision,
     required AuthTokenPair replacement,
-    bool requiresServerVerification = false,
   }) async {
     compareAndSetCalls++;
     final existing = current;
@@ -603,23 +468,6 @@ class _FakeCredentialVault
     current = AuthCredentialSnapshot(
       pair: replacement,
       revision: expectedRevision + 1,
-      requiresServerVerification: requiresServerVerification,
-    );
-    return current;
-  }
-
-  @override
-  Future<AuthCredentialSnapshot?> markCredentialsServerVerified({
-    required int expectedRevision,
-  }) async {
-    markVerifiedCalls++;
-    final existing = current;
-    if (existing == null || existing.revision != expectedRevision) return null;
-    if (!existing.requiresServerVerification) return existing;
-    current = AuthCredentialSnapshot(
-      pair: existing.pair,
-      revision: expectedRevision,
-      requiresServerVerification: false,
     );
     return current;
   }

--- a/rythmrun_frontend_flutter/test/core/services/auth_persistence_offline_window_test.dart
+++ b/rythmrun_frontend_flutter/test/core/services/auth_persistence_offline_window_test.dart
@@ -224,32 +224,6 @@ void main() {
       },
     );
 
-    test(
-      'a migrated pair is ineligible until verified, then bounded',
-      () async {
-        final pair = _pair(base);
-        final harness = build(
-          preferences: <String, Object>{
-            AuthPersistenceService.legacyAccessTokenKey: pair.accessToken,
-            AuthPersistenceService.legacyRefreshTokenKey: pair.refreshToken,
-            AuthPersistenceService.userDataKey: _encodedUser,
-            AuthPersistenceService.lastBackendSyncKey: base.toIso8601String(),
-          },
-        );
-
-        final migrated = await harness.service.readCredentialSnapshot();
-        expect(migrated?.requiresServerVerification, isTrue);
-        expect(await harness.service.canStayLoggedInOffline(), isFalse);
-
-        await harness.service.markCredentialsServerVerified(
-          expectedRevision: migrated!.revision,
-        );
-        expect(await harness.service.canStayLoggedInOffline(), isTrue);
-
-        harness.setNow(base.add(const Duration(days: 8)));
-        expect(await harness.service.canStayLoggedInOffline(), isFalse);
-      },
-    );
   });
 }
 

--- a/rythmrun_frontend_flutter/test/core/services/auth_persistence_service_test.dart
+++ b/rythmrun_frontend_flutter/test/core/services/auth_persistence_service_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -23,182 +22,6 @@ void main() {
       now: () => now,
     );
   }
-
-  test('migrates one coherent IP-2.1 pair and removes plaintext', () async {
-    final secure = _MemorySecureValueStore();
-    final pair = _ip21Pair(now);
-    final preferences = _MemoryPreferences(<String, Object>{
-      AuthPersistenceService.legacyAccessTokenKey: pair.accessToken,
-      AuthPersistenceService.legacyRefreshTokenKey: pair.refreshToken,
-      AuthPersistenceService.userDataKey: _encodedUser,
-      AuthPersistenceService.lastBackendSyncKey:
-          now.subtract(const Duration(hours: 1)).toIso8601String(),
-    });
-
-    final snapshot =
-        await service(
-          secure: secure,
-          preferences: preferences,
-        ).readCredentialSnapshot();
-
-    expect(snapshot?.pair, pair);
-    expect(snapshot?.requiresServerVerification, isTrue);
-    expect(preferences.containsKey('access_token'), isFalse);
-    expect(preferences.containsKey('refresh_token'), isFalse);
-    expect(preferences.containsKey('user_data'), isTrue);
-    expect(preferences.containsKey('last_backend_sync'), isTrue);
-    expect(secure.writeCount, 1);
-  });
-
-  test('retains plaintext when the secure write is interrupted', () async {
-    final secure = _MemorySecureValueStore()..throwAfterNextWrite = true;
-    final pair = _ip21Pair(now);
-    final preferences = _MemoryPreferences(<String, Object>{
-      'access_token': pair.accessToken,
-      'refresh_token': pair.refreshToken,
-      'user_data': _encodedUser,
-    });
-    final persistence = service(secure: secure, preferences: preferences);
-
-    await expectLater(
-      persistence.readCredentialSnapshot(),
-      throwsA(isA<StateError>()),
-    );
-    expect(preferences.containsKey('access_token'), isTrue);
-    expect(preferences.containsKey('refresh_token'), isTrue);
-
-    // The write committed before interruption. A retry treats the read-back
-    // secure envelope as authoritative and finishes plaintext cleanup.
-    final recovered = await persistence.readCredentialSnapshot();
-    expect(recovered?.pair, pair);
-    expect(preferences.containsKey('access_token'), isFalse);
-    expect(preferences.containsKey('refresh_token'), isFalse);
-  });
-
-  test(
-    'resumes after interruption while removing legacy preferences',
-    () async {
-      final secure = _MemorySecureValueStore();
-      final pair = _ip21Pair(now);
-      final preferences = _MemoryPreferences(<String, Object>{
-        'access_token': pair.accessToken,
-        'refresh_token': pair.refreshToken,
-        'user_data': _encodedUser,
-      })..failNextRemoveFor('refresh_token');
-      final persistence = service(secure: secure, preferences: preferences);
-
-      await expectLater(
-        persistence.readCredentialSnapshot(),
-        throwsA(isA<StateError>()),
-      );
-      expect(preferences.containsKey('access_token'), isFalse);
-      expect(preferences.containsKey('refresh_token'), isTrue);
-
-      final recovered = await persistence.readCredentialSnapshot();
-      expect(recovered?.pair, pair);
-      expect(preferences.containsKey('refresh_token'), isFalse);
-      expect(secure.writeCount, 1);
-    },
-  );
-
-  test('existing secure credentials win over stale preferences', () async {
-    final secure = _MemorySecureValueStore();
-    final tokenStore = SecureAuthTokenStore(storage: secure, now: () => now);
-    final securePair = AuthTokenPair(
-      accessToken: 'secure-access',
-      refreshToken: 'secure-refresh',
-    );
-    await tokenStore.write(securePair);
-    final legacyPair = _ip21Pair(now);
-    final preferences = _MemoryPreferences(<String, Object>{
-      'access_token': legacyPair.accessToken,
-      'refresh_token': legacyPair.refreshToken,
-    });
-    final persistence = AuthPersistenceService(
-      tokenStore: tokenStore,
-      preferencesFactory: () async => preferences,
-      now: () => now,
-    );
-
-    final snapshot = await persistence.readCredentialSnapshot();
-
-    expect(snapshot?.pair, securePair);
-    expect(preferences.containsKey('access_token'), isFalse);
-    expect(preferences.containsKey('refresh_token'), isFalse);
-  });
-
-  test('coalesces concurrent migration reads into one secure write', () async {
-    final secure = _MemorySecureValueStore();
-    final pair = _ip21Pair(now);
-    final preferences = _MemoryPreferences(<String, Object>{
-      'access_token': pair.accessToken,
-      'refresh_token': pair.refreshToken,
-      'user_data': _encodedUser,
-    });
-    final persistence = service(secure: secure, preferences: preferences);
-
-    final snapshots = await Future.wait(
-      List<Future<AuthCredentialSnapshot?>>.generate(
-        24,
-        (_) => persistence.readCredentialSnapshot(),
-      ),
-    );
-
-    expect(snapshots, everyElement(isNotNull));
-    expect(snapshots.map((item) => item!.revision).toSet(), hasLength(1));
-    expect(secure.writeCount, 1);
-  });
-
-  test('rejects and removes incomplete or non-IP-2.1 legacy pairs', () async {
-    for (final values in <Map<String, Object>>[
-      <String, Object>{'access_token': 'legacy-access-only'},
-      <String, Object>{
-        'access_token': 'pre-session-access',
-        'refresh_token': 'pre-session-refresh',
-      },
-      <String, Object>{
-        'access_token': _ip21Pair(now).accessToken,
-        'refresh_token':
-            _ip21Pair(
-              now,
-              sessionId: '99999999-9999-4999-8999-999999999999',
-            ).refreshToken,
-      },
-    ]) {
-      final secure = _MemorySecureValueStore();
-      final preferences = _MemoryPreferences(values);
-
-      expect(
-        await service(
-          secure: secure,
-          preferences: preferences,
-        ).readCredentialSnapshot(),
-        isNull,
-      );
-      expect(preferences.containsKey('access_token'), isFalse);
-      expect(preferences.containsKey('refresh_token'), isFalse);
-      expect(secure.values, isEmpty);
-    }
-  });
-
-  test('rejects a legacy pair belonging to another stored user', () async {
-    final secure = _MemorySecureValueStore();
-    final pair = _ip21Pair(now, subject: '8');
-    final preferences = _MemoryPreferences(<String, Object>{
-      'access_token': pair.accessToken,
-      'refresh_token': pair.refreshToken,
-      'user_data': _encodedUser,
-    });
-
-    expect(
-      await service(
-        secure: secure,
-        preferences: preferences,
-      ).readCredentialSnapshot(),
-      isNull,
-    );
-    expect(secure.values, isEmpty);
-  });
 
   test(
     'fresh authentication never stores credentials in preferences',
@@ -308,27 +131,6 @@ void main() {
     expect(secure.values, isEmpty);
   });
 
-  test('migrated credentials are ineligible for offline admission', () async {
-    final secure = _MemorySecureValueStore();
-    final pair = _ip21Pair(now);
-    final preferences = _MemoryPreferences(<String, Object>{
-      'access_token': pair.accessToken,
-      'refresh_token': pair.refreshToken,
-      'user_data': _encodedUser,
-      'last_backend_sync': now.toIso8601String(),
-    });
-    final persistence = service(secure: secure, preferences: preferences);
-
-    final migrated = await persistence.readCredentialSnapshot();
-    expect(await persistence.canStayLoggedInOffline(), isFalse);
-
-    final verified = await persistence.markCredentialsServerVerified(
-      expectedRevision: migrated!.revision,
-    );
-    expect(verified?.requiresServerVerification, isFalse);
-    expect(await persistence.canStayLoggedInOffline(), isTrue);
-  });
-
   test(
     'verified session stays offline-eligible when only access expired',
     () async {
@@ -350,50 +152,12 @@ void main() {
         now: () => offlineNow,
       );
 
-      final migrated = await persistence.readCredentialSnapshot();
-      await persistence.markCredentialsServerVerified(
-        expectedRevision: migrated!.revision,
-      );
+      // A direct write stamps the pair as verified now, so the only reason it
+      // is not a valid online session is the expired access token.
+      await persistence.replaceCredentials(pair);
 
       expect(await persistence.hasValidSession(), isFalse);
       expect(await persistence.canStayLoggedInOffline(), isTrue);
-    },
-  );
-
-  test(
-    'credential cleanup is serialized after an in-flight migration',
-    () async {
-      final pair = _ip21Pair(now);
-      final preferences = _MemoryPreferences(<String, Object>{
-        'access_token': pair.accessToken,
-        'refresh_token': pair.refreshToken,
-        'user_data': _encodedUser,
-        'last_backend_sync': now.toIso8601String(),
-      });
-      final tokenStore = _BlockingAuthTokenStore();
-      final persistence = AuthPersistenceService(
-        tokenStore: tokenStore,
-        preferencesFactory: () async => preferences,
-        now: () => now,
-      );
-
-      final migration = persistence.readCredentialSnapshot();
-      await tokenStore.firstReadStarted.future;
-
-      final cleanup = persistence.clearAuthData();
-      await Future<void>.delayed(Duration.zero);
-      expect(tokenStore.deleteCalls, 0);
-
-      tokenStore.releaseFirstRead.complete();
-      expect((await migration)?.pair, pair);
-      await cleanup;
-
-      expect(await tokenStore.read(), isNull);
-      expect(tokenStore.deleteCalls, 1);
-      expect(preferences.containsKey('access_token'), isFalse);
-      expect(preferences.containsKey('refresh_token'), isFalse);
-      expect(preferences.containsKey('user_data'), isFalse);
-      expect(preferences.containsKey('last_backend_sync'), isFalse);
     },
   );
 }
@@ -460,82 +224,6 @@ final class _MemorySecureValueStore implements SecureValueStore {
   @override
   Future<void> delete(String key) async {
     values.remove(key);
-  }
-}
-
-final class _BlockingAuthTokenStore implements AuthTokenStore {
-  final Completer<void> firstReadStarted = Completer<void>();
-  final Completer<void> releaseFirstRead = Completer<void>();
-  AuthCredentialSnapshot? current;
-  bool _didBlockRead = false;
-  int deleteCalls = 0;
-
-  @override
-  Future<AuthCredentialSnapshot?> read() async {
-    if (!_didBlockRead) {
-      _didBlockRead = true;
-      firstReadStarted.complete();
-      await releaseFirstRead.future;
-    }
-    return current;
-  }
-
-  @override
-  Future<AuthCredentialSnapshot> write(
-    AuthTokenPair pair, {
-    bool requiresServerVerification = false,
-  }) async {
-    current = AuthCredentialSnapshot(
-      pair: pair,
-      revision: (current?.revision ?? 0) + 1,
-      requiresServerVerification: requiresServerVerification,
-    );
-    return current!;
-  }
-
-  @override
-  Future<AuthCredentialSnapshot?> compareAndSet({
-    required int expectedRevision,
-    required AuthTokenPair replacement,
-    bool requiresServerVerification = false,
-  }) async {
-    if (current?.revision != expectedRevision) return null;
-    return write(
-      replacement,
-      requiresServerVerification: requiresServerVerification,
-    );
-  }
-
-  @override
-  Future<AuthCredentialSnapshot?> markServerVerified({
-    required int expectedRevision,
-  }) async {
-    final existing = current;
-    if (existing == null || existing.revision != expectedRevision) return null;
-    current = AuthCredentialSnapshot(
-      pair: existing.pair,
-      revision: existing.revision,
-      requiresServerVerification: false,
-    );
-    return current;
-  }
-
-  @override
-  Future<AuthCredentialSnapshot?> advanceObservedClock() async => current;
-
-  @override
-  Future<void> delete() async {
-    deleteCalls++;
-    current = null;
-  }
-
-  @override
-  Future<bool> deleteIfRevision(int expectedRevision) async {
-    final existing = current;
-    if (existing == null) return true;
-    if (existing.revision != expectedRevision) return false;
-    await delete();
-    return true;
   }
 }
 

--- a/rythmrun_frontend_flutter/test/core/services/auth_token_store_test.dart
+++ b/rythmrun_frontend_flutter/test/core/services/auth_token_store_test.dart
@@ -96,23 +96,6 @@ void main() {
     );
   });
 
-  test('server verification uses revision CAS', () async {
-    final store = SecureAuthTokenStore(storage: _MemorySecureValueStore());
-    final migrated = await store.write(
-      AuthTokenPair(accessToken: 'access-a', refreshToken: 'refresh-a'),
-      requiresServerVerification: true,
-    );
-
-    expect(
-      await store.markServerVerified(expectedRevision: migrated.revision + 1),
-      isNull,
-    );
-    final verified = await store.markServerVerified(
-      expectedRevision: migrated.revision,
-    );
-    expect(verified?.requiresServerVerification, isFalse);
-    expect(verified?.revision, migrated.revision);
-  });
 }
 
 final class _MemorySecureValueStore implements SecureValueStore {

--- a/rythmrun_frontend_flutter/test/data/repositories/auth_repository_impl_gate_test.dart
+++ b/rythmrun_frontend_flutter/test/data/repositories/auth_repository_impl_gate_test.dart
@@ -557,7 +557,6 @@ class _MemoryAuthLocalDataSource extends AuthLocalDataSource {
       refreshToken: 'refresh-before',
     ),
     revision: 1,
-    requiresServerVerification: false,
   );
   UserEntity? user;
   bool hasLastBackendSync = false;
@@ -571,7 +570,6 @@ class _MemoryAuthLocalDataSource extends AuthLocalDataSource {
         refreshToken: authResponse.refreshToken,
       ),
       revision: (snapshot?.revision ?? 0) + 1,
-      requiresServerVerification: false,
     );
     user = authResponse.toUserEntity();
     hasLastBackendSync = true;
@@ -584,21 +582,14 @@ class _MemoryAuthLocalDataSource extends AuthLocalDataSource {
   Future<AuthCredentialSnapshot?> compareAndSetCredentials({
     required int expectedRevision,
     required AuthTokenPair replacement,
-    bool requiresServerVerification = false,
   }) async {
     if (snapshot?.revision != expectedRevision) return null;
     snapshot = AuthCredentialSnapshot(
       pair: replacement,
       revision: expectedRevision + 1,
-      requiresServerVerification: requiresServerVerification,
     );
     return snapshot;
   }
-
-  @override
-  Future<AuthCredentialSnapshot?> markCredentialsServerVerified({
-    required int expectedRevision,
-  }) async => snapshot;
 
   @override
   Future<void> updateUserData(UserEntity updatedUser) async {


### PR DESCRIPTION
…ication (Phase 3a)

No production users hold pre-Keystore plaintext tokens, so the one-time migration from the two historical SharedPreferences keys — and the requiresServerVerification / markServerVerified machinery that flagged a migrated pair as unverified until a backend check — is dead weight. Removing it also de-tangles the M2 refresh seam (Phase 3b): the request coordinator no longer has a verification-stamp special case.

Deleted across 5 lib files (net -854 lines):
- auth_token_store.dart: requiresServerVerification field/params and markServerVerified. The secure envelope stops storing the flag; reads stay tolerant of an older envelope that still carries it.
- auth_persistence_service.dart: the whole legacy plaintext migration (read/validate/decode/coalesce), the legacy keys, the migration FIFO, and markCredentialsServerVerified. Offline admission keeps only the JWT-expiry + lastVerifiedAtMs window check.
- authenticated_request_coordinator.dart: the verification-stamp branch in _completeSuccessfulRequest and the migration branch in markCurrentCredentialsServerVerified, which now only resets the backend-sync timer under the auth gate.
- auth_local_datasource.dart / auth_repository_impl.dart: dropped the pass-throughs; validateSession server-checks on needsBackendSync() alone.

Behavior note: lastVerifiedAtMs is no longer re-anchored on a successful /me; it is anchored on login and every refresh rotation (which stay frequent), so the offline window still resets regularly.

Tests: 15 dead legacy-migration / verification-stamp tests removed. Client suite green at 344 passed; analyzer 9 issues, 0 warnings, 0 errors; dart format clean.