### PR TITLE
fix(auth): accept same-session rotations, evict failed refresh flight…

### DIFF
--- a/docs/_engineering/auth-hardening/MASTER-PLAN.md
+++ b/docs/_engineering/auth-hardening/MASTER-PLAN.md
@@ -4,7 +4,7 @@ published: false
 
 # Auth Hardening & Tunable Timing — Master Plan
 
-**Status:** Phases 0–2 done · Phase 3a complete — awaiting review · **Owner:** maintainer · **Created:** 2026-08-11
+**Status:** Phases 0–2 done · Phase 3 complete (3a + 3b) — awaiting review · **Owner:** maintainer · **Created:** 2026-08-11
 **Source:** auth + refresh audit (16 confirmed findings, 1 plausible, 2 refuted)
 **Relationship to the improvement program:** this is IP-2 follow-up work. It does
 not replace `IP-2-auth-account-privacy.md`; when a phase here lands, its evidence
@@ -641,9 +641,10 @@ Legend: `[ ]` pending · `[~]` in progress · `[x]` done
 ### Phase 3 — Client credential simplification
 - [x] **3a** legacy migration + `requiresServerVerification` / `markServerVerified` deleted across 5 lib files (net −854 lines). Kept a simplified gate-protected `markCurrentCredentialsServerVerified` — its only surviving job is the sync-timer reset, not a verification stamp.
 - [x] **3a** dead legacy-migration + verification-stamp tests removed (15 tests); suite green at 344, analyzer 9
-- [ ] **M2** same-session rotation accepted (on simplified coordinator)
-- [ ] **A3** failed flights evicted
-- [ ] **A4** avatar replay policy
+- [x] **M2** same-session rotation accepted in `_completeSuccessfulRequest` — a request that succeeds while a concurrent refresh rotates the pair is no longer failed; only a cleared vault or a different `sid`/`sub` throws. Undecodable tokens fail closed.
+- [x] **A3** failed refresh flights evicted the moment they error (a failing refresh never advances the revision, so the cached failure would otherwise be replayed to every overlapping request); a success stays cached until the last operation ends
+- [x] **A4** `getUploadUrl` now sends `replayPolicy: idempotent` — a lost-response retry re-mints a presigned PUT + single-use intent instead of failing the upload
+- [x] **3b** new tests: same-session rotation returns its result; different-session rotation rejected; failed flight evicted → later request retries fresh; avatar upload-url opts into idempotent replay. Suite 344 → 348, analyzer 9
 
 ### Phase 4 — Error contract
 - [ ] **M4** change-password via `ErrorHandler`
@@ -701,7 +702,9 @@ true starting point. Phase 0 adds config-spine tests, taking the backend to
 the M5 sweep and M3 rate-limit tests → 508 passed / 7 skipped / 515 total.
 Phase 2 adds four grace-window rotation tests → 512 passed / 7 skipped / 519
 total. Phase 3a is client-only and **deliberately drops** the Flutter count from
-359 to 344 by deleting 15 dead legacy-migration / verification-stamp tests.)
+359 to 344 by deleting 15 dead legacy-migration / verification-stamp tests.
+Phase 3b adds four refresh-seam tests (M2 same-session accept/reject, A3
+failed-flight eviction, A4 avatar replay policy) → Flutter 348.)
 
 **Four known traps** (from `CLAUDE.md`, repeated because they cost real time):
 1. Use `npm test`, never `npx jest` — the suite is native ESM.

--- a/rythmrun_frontend_flutter/lib/core/network/authenticated_request_coordinator.dart
+++ b/rythmrun_frontend_flutter/lib/core/network/authenticated_request_coordinator.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:jwt_decoder/jwt_decoder.dart';
+
 import '../../data/datasources/auth_remote_datasource.dart';
 import '../../data/models/auth_response_model.dart';
 import '../services/auth_token_store.dart';
@@ -167,6 +169,21 @@ class AuthenticatedRequestCoordinator implements AuthenticatedRequestExecutor {
 
     final flight = _performRefresh(expected);
     _refreshFlights[expected.revision] = flight;
+    // A failed rotation must not linger for later requests on this revision: a
+    // failing refresh never advances the revision, so the cached failure would
+    // be replayed to every overlapping request. Evict it the moment it errors so
+    // the next request starts a fresh attempt. A success stays cached until the
+    // last operation ends, keeping concurrent requests on one rotation.
+    unawaited(
+      flight.then(
+        (_) {},
+        onError: (Object _, StackTrace _) {
+          if (identical(_refreshFlights[expected.revision], flight)) {
+            _refreshFlights.remove(expected.revision);
+          }
+        },
+      ),
+    );
     return flight;
   }
 
@@ -378,6 +395,12 @@ class AuthenticatedRequestCoordinator implements AuthenticatedRequestExecutor {
     final current = await _readSnapshot();
     if (_sameCredentials(current, expected)) return;
 
+    // A concurrent refresh may have rotated the pair while this request was in
+    // flight. The request still succeeded against the backend, so accept a
+    // same-session rotation and fail only when the vault was cleared or now
+    // holds a different account or session.
+    if (current != null && _sameSession(current, expected)) return;
+
     throw const AuthSessionUnavailable(
       AuthSessionUnavailableReason.credentialsChanged,
     );
@@ -399,6 +422,36 @@ class AuthenticatedRequestCoordinator implements AuthenticatedRequestExecutor {
     return left != null &&
         left.revision == right.revision &&
         left.pair == right.pair;
+  }
+
+  /// True when both access tokens name the same account and session, i.e. one
+  /// is a rotation of the other. A token that cannot be decoded, or is missing
+  /// either claim, is treated as a mismatch so the caller fails closed.
+  static bool _sameSession(
+    AuthCredentialSnapshot left,
+    AuthCredentialSnapshot right,
+  ) {
+    final leftClaims = _sessionClaims(left.pair.accessToken);
+    if (leftClaims == null) return false;
+    final rightClaims = _sessionClaims(right.pair.accessToken);
+    if (rightClaims == null) return false;
+    return leftClaims.sid == rightClaims.sid &&
+        leftClaims.sub == rightClaims.sub;
+  }
+
+  static ({String sid, String sub})? _sessionClaims(String accessToken) {
+    final Map<String, dynamic> claims;
+    try {
+      claims = JwtDecoder.decode(accessToken);
+    } catch (_) {
+      return null;
+    }
+    final sid = claims['sid'];
+    final sub = claims['sub'];
+    if (sid is! String || sid.isEmpty || sub is! String || sub.isEmpty) {
+      return null;
+    }
+    return (sid: sid, sub: sub);
   }
 
   static Map<String, String> _headersFor(AuthCredentialSnapshot snapshot) {

--- a/rythmrun_frontend_flutter/lib/data/datasources/avatar_remote_datasource.dart
+++ b/rythmrun_frontend_flutter/lib/data/datasources/avatar_remote_datasource.dart
@@ -84,6 +84,7 @@ class AvatarRemoteDataSourceImpl implements AvatarRemoteDataSource {
     int sizeBytes,
   ) async {
     final response = await authenticatedRequests.execute(
+      replayPolicy: AuthenticatedReplayPolicy.idempotent,
       request:
           (authHeaders) => httpClient.post(
             AppConfig.getUrl('/avatar/upload-url'),

--- a/rythmrun_frontend_flutter/test/core/network/authenticated_request_coordinator_test.dart
+++ b/rythmrun_frontend_flutter/test/core/network/authenticated_request_coordinator_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -404,6 +405,142 @@ void main() {
     expect(vault.current!.pair.accessToken, 'access-2');
   });
 
+  test(
+    'a request completing across a same-session rotation returns its result',
+    () async {
+      vault.current = AuthCredentialSnapshot(
+        pair: _jwtPair(sid: 'session-1', sub: 'user-1', jti: 'access-a'),
+        revision: 1,
+      );
+
+      final result = await coordinator.execute<String>(
+        request: (_) async {
+          // A concurrent refresh rotates the pair to a fresh same-session token
+          // while this request is in flight; the request still succeeded.
+          vault.current = AuthCredentialSnapshot(
+            pair: _jwtPair(sid: 'session-1', sub: 'user-1', jti: 'access-b'),
+            revision: 2,
+          );
+          return 'ok';
+        },
+      );
+
+      expect(result, 'ok');
+    },
+  );
+
+  test(
+    'a request completing across a different-session rotation is rejected',
+    () async {
+      vault.current = AuthCredentialSnapshot(
+        pair: _jwtPair(sid: 'session-1', sub: 'user-1', jti: 'access-a'),
+        revision: 1,
+      );
+
+      await expectLater(
+        coordinator.execute<String>(
+          request: (_) async {
+            // A different session (a fresh login on this device) must not be
+            // mistaken for a rotation of the in-flight request's session.
+            vault.current = AuthCredentialSnapshot(
+              pair: _jwtPair(sid: 'session-2', sub: 'user-1', jti: 'access-b'),
+              revision: 2,
+            );
+            return 'ok';
+          },
+        ),
+        throwsA(
+          isA<AuthSessionUnavailable>().having(
+            (error) => error.reason,
+            'reason',
+            AuthSessionUnavailableReason.credentialsChanged,
+          ),
+        ),
+      );
+    },
+  );
+
+  test(
+    'a failed refresh flight is evicted so a later request retries fresh',
+    () async {
+      // Hold one operation open on revision 1 so the shared flight is not
+      // cleared when the failing request ends; only the failed-flight eviction
+      // can remove it. Without eviction the later request would inherit the
+      // cached failure instead of refreshing anew.
+      final keeperHold = Completer<void>();
+      final keeperStarted = Completer<void>();
+      final keeper = coordinator.execute<String>(
+        request: (_) async {
+          keeperStarted.complete();
+          await keeperHold.future;
+          return 'keeper';
+        },
+      );
+      await keeperStarted.future;
+
+      var refreshAttempt = 0;
+      final firstRefreshReached = Completer<void>();
+      final releaseFirstRefresh = Completer<void>();
+      remote.onRefresh = (_) async {
+        refreshAttempt++;
+        if (refreshAttempt == 1) {
+          firstRefreshReached.complete();
+          await releaseFirstRefresh.future;
+          throw const NetworkException(
+            'offline',
+            kind: NetworkFailureKind.offline,
+          );
+        }
+        return _response(access: 'access-2', refresh: 'refresh-2');
+      };
+
+      final firstRequest = coordinator.execute<String>(
+        replayPolicy: AuthenticatedReplayPolicy.idempotent,
+        request: (headers) async {
+          if (headers['Authorization'] == 'Bearer access-1') {
+            throw UnauthorizedException(
+              'expired',
+              code: AuthenticatedRequestCoordinator.invalidAccessCode,
+            );
+          }
+          return 'first-replayed';
+        },
+      );
+      await firstRefreshReached.future;
+
+      releaseFirstRefresh.complete();
+      await expectLater(
+        firstRequest,
+        throwsA(
+          isA<AuthSessionUnavailable>().having(
+            (error) => error.reason,
+            'reason',
+            AuthSessionUnavailableReason.network,
+          ),
+        ),
+      );
+
+      final secondResult = await coordinator.execute<String>(
+        replayPolicy: AuthenticatedReplayPolicy.idempotent,
+        request: (headers) async {
+          if (headers['Authorization'] == 'Bearer access-1') {
+            throw UnauthorizedException(
+              'expired',
+              code: AuthenticatedRequestCoordinator.invalidAccessCode,
+            );
+          }
+          expect(headers['Authorization'], 'Bearer access-2');
+          return 'second-replayed';
+        },
+      );
+
+      expect(secondResult, 'second-replayed');
+      expect(remote.refreshCalls, 2);
+
+      keeperHold.complete();
+      await keeper.catchError((_) => 'keeper');
+    },
+  );
 }
 
 Future<void> _accessRejectedRequest(
@@ -429,6 +566,36 @@ AuthCredentialSnapshot _snapshot({
     pair: AuthTokenPair(accessToken: access, refreshToken: refresh),
     revision: revision,
   );
+}
+
+AuthTokenPair _jwtPair({
+  required String sid,
+  required String sub,
+  required String jti,
+}) {
+  return AuthTokenPair(
+    accessToken: _jwt(<String, Object>{
+      'sub': sub,
+      'sid': sid,
+      'jti': jti,
+      'typ': 'access',
+    }),
+    refreshToken: _jwt(<String, Object>{
+      'sub': sub,
+      'sid': sid,
+      'jti': '$jti-refresh',
+      'typ': 'refresh',
+    }),
+  );
+}
+
+String _jwt(Map<String, Object> claims) {
+  String encode(Object value) {
+    return base64Url.encode(utf8.encode(jsonEncode(value))).replaceAll('=', '');
+  }
+
+  return '${encode(<String, Object>{'alg': 'HS256', 'typ': 'JWT'})}.'
+      '${encode(claims)}.${encode('signature')}';
 }
 
 AuthResponseModel _response({required String access, required String refresh}) {

--- a/rythmrun_frontend_flutter/test/data/repositories/avatar_repository_impl_test.dart
+++ b/rythmrun_frontend_flutter/test/data/repositories/avatar_repository_impl_test.dart
@@ -45,6 +45,24 @@ void main() {
       });
     });
 
+    test('requests upload authorization with idempotent replay', () async {
+      final authenticatedRequests = _FakeAuthenticatedRequests();
+      final dataSource = AvatarRemoteDataSourceImpl(
+        _FakeRemoteHttpClient(),
+        authenticatedRequests,
+      );
+
+      // Fetching an upload URL is safe to replay after a refresh: it only mints
+      // a fresh presigned PUT and single-use intent, so a lost-response retry
+      // must not fail the upload.
+      await dataSource.getUploadUrl('jpg', 'image/jpeg', 321);
+
+      expect(
+        authenticatedRequests.lastReplayPolicy,
+        AuthenticatedReplayPolicy.idempotent,
+      );
+    });
+
     test('fetches an authenticated signed avatar read URL', () async {
       final httpClient = _FakeRemoteHttpClient();
       final dataSource = AvatarRemoteDataSourceImpl(
@@ -336,11 +354,14 @@ class _FakeAuthRepository implements AuthRepository {
 }
 
 class _FakeAuthenticatedRequests implements AuthenticatedRequestExecutor {
+  AuthenticatedReplayPolicy? lastReplayPolicy;
+
   @override
   Future<T> execute<T>({
     required Future<T> Function(Map<String, String> authHeaders) request,
     AuthenticatedReplayPolicy replayPolicy = AuthenticatedReplayPolicy.never,
   }) {
+    lastReplayPolicy = replayPolicy;
     return request(const <String, String>{
       'Authorization': 'Bearer access-token',
     });


### PR DESCRIPTION
…s, replay avatar upload-url (Phase 3b)

Three refresh-seam fixes on the now-simplified coordinator.

M2 — _completeSuccessfulRequest no longer fails a request that already succeeded against the backend just because a concurrent refresh rotated the credential pair mid-flight. It now accepts a same-session rotation (same sid/sub in the access token) and throws credentialsChanged only when the vault was cleared or now holds a different account or session. A token that cannot be decoded fails closed.

A3 — a failed refresh flight is evicted the moment it errors. A failing refresh never advances the revision, so the cached failure was handed to every overlapping request on that revision until traffic fully drained; the next request now starts a fresh attempt instead. A successful flight still stays cached until the last operation ends, so concurrent requests share one rotation.

A4 — getUploadUrl opts into idempotent replay, so a lost-response retry after a refresh re-mints a presigned PUT + single-use intent instead of failing the upload. confirm/read already replayed; the upload-url step was the gap.

Tests: a request completing across a same-session rotation returns its result; a different-session rotation is rejected; a failed flight is evicted so a later request retries fresh; the avatar upload-url path opts into idempotent replay. Flutter 344 -> 348, analyzer 9.