### PR TITLE
refactor(auth): error contract — one stable `code` field, curated cli…

### DIFF
--- a/RythmRun_backend_nodejs/src/__tests__/activity-image-error-mapping.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/activity-image-error-mapping.test.ts
@@ -81,7 +81,7 @@ describe('typed activity-image error mapping (IP-2.6)', () => {
     await controller.listImages(fakeRequest(), fakeResponse(captured));
 
     expect(captured.statusCode).toBe(statusCode);
-    expect(captured.body).toMatchObject({ status: 'error', error: code });
+    expect(captured.body).toMatchObject({ status: 'error', code });
   });
 
   it('keeps the status when the message text changes', async () => {
@@ -99,7 +99,7 @@ describe('typed activity-image error mapping (IP-2.6)', () => {
 
     expect(captured.statusCode).toBe(400);
     expect(captured.body).toMatchObject({
-      error: 'ACTIVITY_IMAGE_KEY_INVALID',
+      code: 'ACTIVITY_IMAGE_KEY_INVALID',
       message: 'Completely different wording',
     });
   });

--- a/RythmRun_backend_nodejs/src/__tests__/api-abuse-controls.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/api-abuse-controls.test.ts
@@ -215,7 +215,7 @@ describe('IP-2.6 authentication rate limits', () => {
 
       expect(blocked.statusCode).toBe(429);
       expect(blocked.body).toMatchObject({
-        error: 'AUTH_RATE_LIMITED',
+        code: 'AUTH_RATE_LIMITED',
         retryable: true,
         statusCode: 429,
       });
@@ -563,7 +563,7 @@ describe('IP-2.6 authentication rate limits', () => {
       );
       expect(blocked.statusCode).toBe(429);
       expect(blocked.body).toMatchObject({
-        error: 'AUTH_RATE_LIMITED',
+        code: 'AUTH_RATE_LIMITED',
         statusCode: 429,
       });
     } finally {

--- a/RythmRun_backend_nodejs/src/__tests__/auth.middleware.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/auth.middleware.test.ts
@@ -70,7 +70,7 @@ describe('access authentication middleware', () => {
     expect(result.status).toHaveBeenCalledWith(401);
     expect(result.json).toHaveBeenCalledWith(
       expect.objectContaining({
-        error: 'AUTH_ACCESS_INVALID',
+        code: 'AUTH_ACCESS_INVALID',
         message: 'Authentication is required',
         statusCode: 401,
       }),
@@ -87,7 +87,7 @@ describe('access authentication middleware', () => {
     expect(result.next).not.toHaveBeenCalled();
     expect(result.json).toHaveBeenCalledWith(
       expect.objectContaining({
-        error: 'AUTH_ACCESS_INVALID',
+        code: 'AUTH_ACCESS_INVALID',
         message: 'Authentication is required',
         statusCode: 401,
       }),
@@ -109,7 +109,7 @@ describe('access authentication middleware', () => {
     expect(result.status).toHaveBeenCalledWith(503);
     expect(result.json).toHaveBeenCalledWith(
       expect.objectContaining({
-        error: 'AUTH_SERVICE_UNAVAILABLE',
+        code: 'AUTH_SERVICE_UNAVAILABLE',
         message: 'Authentication service is temporarily unavailable',
         statusCode: 503,
         retryable: true,

--- a/RythmRun_backend_nodejs/src/__tests__/http-security-boundary.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/http-security-boundary.test.ts
@@ -209,7 +209,7 @@ describe('HTTP security boundaries', () => {
 
     expect(response.statusCode).toBe(400);
     expect(response.body).toMatchObject({
-      error: 'REGISTRATION_FAILED',
+      code: 'REGISTRATION_FAILED',
       message: 'Validation failed',
       statusCode: 400,
     });
@@ -230,7 +230,7 @@ describe('HTTP security boundaries', () => {
 
     expect(response.statusCode).toBe(400);
     expect(response.body).toMatchObject({
-      error: 'PROFILE_UPDATE_FAILED',
+      code: 'PROFILE_UPDATE_FAILED',
       message: 'Validation failed',
       statusCode: 400,
     });
@@ -337,7 +337,7 @@ describe('HTTP security boundaries', () => {
 
     expect(response.statusCode).toBe(503);
     expect(response.body).toMatchObject({
-      error: 'AUTH_GOOGLE_UNAVAILABLE',
+      code: 'AUTH_GOOGLE_UNAVAILABLE',
       message: 'Google authentication is temporarily unavailable',
       retryable: true,
       statusCode: 503,
@@ -361,7 +361,7 @@ describe('HTTP security boundaries', () => {
 
     expect(response.statusCode).toBe(400);
     expect(response.body).toMatchObject({
-      error: 'GOOGLE_AUTH_FAILED',
+      code: 'GOOGLE_AUTH_FAILED',
       message: 'Validation failed',
       statusCode: 400,
     });
@@ -378,12 +378,35 @@ describe('HTTP security boundaries', () => {
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toMatchObject({
-      error: 'AUTH_REFRESH_INVALID',
+      code: 'AUTH_REFRESH_INVALID',
       message: 'Refresh session is invalid',
       statusCode: 401,
     });
     expect(authenticate).not.toHaveBeenCalled();
     expect(userService.refreshToken).not.toHaveBeenCalled();
+  });
+
+  it('emits a well-formed stable code on every auth error and drops the legacy error field', async () => {
+    // Phase 4 error contract (P1): the stable code lives in `code`; the old
+    // `error` field is gone entirely, so the client can read one field with one
+    // meaning across validation (400), typed auth (401), and retryable (503).
+    userService.googleLogin.mockRejectedValueOnce(googleAuthUnavailableError());
+
+    const responses = await Promise.all([
+      requestJson(server, 'POST', '/api/users/register', { username: 'x' }),
+      requestJson(server, 'POST', '/api/users/refresh-token', {}),
+      requestJson(server, 'POST', '/api/users/auth/google', { idToken: 't' }),
+    ]);
+
+    const stableCode = /^[A-Z][A-Z0-9_]+$/;
+    for (const response of responses) {
+      expect(response.statusCode).toBeGreaterThanOrEqual(400);
+      const body = response.body as Record<string, unknown>;
+      expect(typeof body.code).toBe('string');
+      expect(body.code as string).toMatch(stableCode);
+      expect(typeof body.message).toBe('string');
+      expect(body).not.toHaveProperty('error');
+    }
   });
 
   it('returns the safe current-user profile through the protected route', async () => {

--- a/RythmRun_backend_nodejs/src/__tests__/rate-limit.middleware.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/rate-limit.middleware.test.ts
@@ -202,7 +202,7 @@ describe('rate limit middleware', () => {
     expect(blocked.statusCode).toBe(429);
     expect(blocked.headers['Retry-After']).toBe(String(WINDOW_MS / 1000));
     expect(blocked.body).toMatchObject({
-      error: 'AUTH_RATE_LIMITED',
+      code: 'AUTH_RATE_LIMITED',
       message: 'Too many requests. Please wait and try again.',
       retryable: true,
       statusCode: 429,

--- a/RythmRun_backend_nodejs/src/__tests__/user-controller-verify.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/user-controller-verify.test.ts
@@ -124,7 +124,7 @@ describe('UserController email verification', () => {
     );
 
     expect(res.statusCode).toBe(429);
-    expect((res.body as { error: string }).error).toBe(
+    expect((res.body as { code: string }).code).toBe(
       'AUTH_VERIFICATION_RATE_LIMITED',
     );
   });

--- a/RythmRun_backend_nodejs/src/controllers/activity-image.controller.ts
+++ b/RythmRun_backend_nodejs/src/controllers/activity-image.controller.ts
@@ -155,7 +155,7 @@ export class ActivityImageController {
     if (error instanceof ActivityImageServiceError) {
       return res.status(error.statusCode).json({
         status: 'error',
-        error: error.code,
+        code: error.code,
         message: error.message,
       });
     }

--- a/RythmRun_backend_nodejs/src/controllers/user.controller.ts
+++ b/RythmRun_backend_nodejs/src/controllers/user.controller.ts
@@ -41,7 +41,7 @@ function sendError(
 ): Response {
   if (error instanceof AuthApplicationError) {
     return res.status(error.statusCode).json({
-      error: error.code,
+      code: error.code,
       message: error.message,
       retryable: error.retryable,
       statusCode: error.statusCode,
@@ -50,15 +50,16 @@ function sendError(
   }
   if (error instanceof AccountDeletionServiceError) {
     return res.status(error.statusCode).json({
-      error: error.code,
+      code: error.code,
       message: error.message,
+      retryable: error.retryable,
       statusCode: error.statusCode,
       timestamp: new Date().toISOString(),
     });
   }
   if (error instanceof DtoValidationError) {
     return res.status(400).json({
-      error: options.validationCode,
+      code: options.validationCode,
       message: 'Validation failed',
       statusCode: 400,
       timestamp: new Date().toISOString(),
@@ -68,7 +69,7 @@ function sendError(
   const category = error instanceof Error ? error.name : 'UnknownError';
   console.error(`${options.unexpectedOperation} failed (${category})`);
   return res.status(500).json({
-    error: 'INTERNAL_ERROR',
+    code: 'INTERNAL_ERROR',
     message: 'Internal server error',
     statusCode: 500,
     timestamp: new Date().toISOString(),

--- a/RythmRun_backend_nodejs/src/errors/account-deletion.error.ts
+++ b/RythmRun_backend_nodejs/src/errors/account-deletion.error.ts
@@ -8,6 +8,7 @@ export class AccountDeletionServiceError extends Error {
     readonly code: AccountDeletionErrorCode,
     readonly statusCode: number,
     message: string,
+    readonly retryable = false,
   ) {
     super(message);
     this.name = 'AccountDeletionServiceError';

--- a/RythmRun_backend_nodejs/src/middleware/auth.middleware.ts
+++ b/RythmRun_backend_nodejs/src/middleware/auth.middleware.ts
@@ -13,7 +13,7 @@ export interface AccessTokenAuthenticator {
 
 function sendInvalidAccess(res: Parameters<RequestHandler>[1]): void {
   res.status(401).json({
-    error: 'AUTH_ACCESS_INVALID',
+    code: 'AUTH_ACCESS_INVALID',
     message: 'Authentication is required',
     statusCode: 401,
     timestamp: new Date().toISOString(),
@@ -24,7 +24,7 @@ function sendAuthServiceUnavailable(
   res: Parameters<RequestHandler>[1],
 ): void {
   res.status(503).json({
-    error: 'AUTH_SERVICE_UNAVAILABLE',
+    code: 'AUTH_SERVICE_UNAVAILABLE',
     message: 'Authentication service is temporarily unavailable',
     statusCode: 503,
     retryable: true,

--- a/RythmRun_backend_nodejs/src/middleware/rate-limit.middleware.ts
+++ b/RythmRun_backend_nodejs/src/middleware/rate-limit.middleware.ts
@@ -269,7 +269,7 @@ export function createRateLimiter(
         .status(error.statusCode)
         .set('Retry-After', String(retryAfterSeconds))
         .json({
-          error: error.code,
+          code: error.code,
           message: error.message,
           retryable: error.retryable,
           statusCode: error.statusCode,

--- a/docs/_engineering/auth-hardening/MASTER-PLAN.md
+++ b/docs/_engineering/auth-hardening/MASTER-PLAN.md
@@ -4,7 +4,7 @@ published: false
 
 # Auth Hardening & Tunable Timing — Master Plan
 
-**Status:** Phases 0, 1, 3 done · **Phase 2 (M1 grace window) reverted** — broken on real PostgreSQL, restored strict reuse detection · **Owner:** maintainer · **Created:** 2026-08-11
+**Status:** Phases 0, 1, 3, 4 done · **Phase 2 (M1 grace window) reverted** — broken on real PostgreSQL, restored strict reuse detection · Next: Phase 5 · **Owner:** maintainer · **Created:** 2026-08-11
 **Source:** auth + refresh audit (16 confirmed findings, 1 plausible, 2 refuted)
 **Relationship to the improvement program:** this is IP-2 follow-up work. It does
 not replace `IP-2-auth-account-privacy.md`; when a phase here lands, its evidence
@@ -639,11 +639,11 @@ Legend: `[ ]` pending · `[~]` in progress · `[x]` done
 - [x] **3b** new tests: same-session rotation returns its result; different-session rotation rejected; failed flight evicted → later request retries fresh; avatar upload-url opts into idempotent replay. Suite 344 → 348, analyzer 9
 
 ### Phase 4 — Error contract
-- [ ] **M4** change-password via `ErrorHandler`
-- [ ] **C2** `AuthSessionFailure` branch
-- [ ] **C3** `AUTH_USERNAME_TAKEN` arm + dead fallbacks deleted
-- [ ] **C4** dead validation parser removed
-- [ ] **P1** `error` field renamed to `code`; regex heuristic deleted; boundary test
+- [x] **M4** `change_password_provider` routes catches through `ErrorHandler.getErrorMessage` (typed `on AuthSessionFailure` + a catch-all), replacing the banned `toString().replaceFirst('Exception: ')`.
+- [x] **C2** `ErrorHandler` gains an early `AuthSessionFailure` branch that returns the failure's curated `.message`.
+- [x] **C3** switch arms added for `AUTH_USERNAME_TAKEN`, `AUTH_PASSWORD_INVALID`, `AUTH_PASSWORD_UNAVAILABLE` (and `AUTH_USER_NOT_FOUND`, added after an adversarial verification pass flagged it as an in-family code left uncurated — it is thrown from the same change-password/delete/profile flows and otherwise degraded to a generic 404); the dead string-matching credential/username block deleted.
+- [x] **C4** unreachable validation parser removed (`_parseValidationError` + `_friendlyValidationMessage` + `_getErrorPriority`, and the now-unused `dart:convert` import).
+- [x] **P1** stable code moved from `error` → `code` and `error` dropped **in every emitter the client reads**, not just `user.controller.ts`: also `auth.middleware.ts` (incl. the load-bearing `AUTH_ACCESS_INVALID` the coordinator branches on), `rate-limit.middleware.ts`, and `activity-image.controller.ts` (`activity.controller.ts` already emitted `code`). Client `http_client.dart` reads `code` only; `_looksLikeStableErrorCode` + the `error` fallback deleted. `retryable` added to the deletion envelope (`AccountDeletionServiceError` gained a `retryable = false` field for Phase 5's Google-503 case). Boundary test asserts every auth error carries a well-formed `code` and no `error` key; a client test locks that a legacy `error`-only body yields no code.
 
 ### Phase 5 — Auth core hardening
 - [ ] **B2** reset tokens killed on password change
@@ -700,7 +700,11 @@ suite passes 7/7. Phase 3a is client-only and **deliberately drops** the Flutter
 count from 359 to 344 by deleting 15 dead legacy-migration / verification-stamp
 tests.
 Phase 3b adds four refresh-seam tests (M2 same-session accept/reject, A3
-failed-flight eviction, A4 avatar replay policy) → Flutter 348.)
+failed-flight eviction, A4 avatar replay policy) → Flutter 348. Phase 4 (error
+contract) adds a backend boundary test → **513 passed / 513 total** CI-equivalent
+(506 / 7 skipped / 513 local) and client tests locking the removed `error`
+fallback, the new code arms, and the `AuthSessionFailure` branch → **Flutter 352**;
+analyzer holds at 9.)
 
 **Four known traps** (from `CLAUDE.md`, repeated because they cost real time):
 1. Use `npm test`, never `npx jest` — the suite is native ESM.

--- a/rythmrun_frontend_flutter/lib/core/network/http_client.dart
+++ b/rythmrun_frontend_flutter/lib/core/network/http_client.dart
@@ -120,19 +120,11 @@ class AppHttpClient {
         try {
           final decodedBody = json.decode(response.body);
           if (decodedBody is Map<String, dynamic>) {
-            final responseError = decodedBody['error'];
-            final responseMessage = decodedBody['message'] ?? responseError;
+            final responseMessage = decodedBody['message'];
             if (responseMessage is String && responseMessage.isNotEmpty) {
               errorMessage = responseMessage;
             }
-            final explicitCode = decodedBody['code'];
-            final responseCode =
-                explicitCode is String && explicitCode.isNotEmpty
-                    ? explicitCode
-                    : responseError is String &&
-                        _looksLikeStableErrorCode(responseError)
-                    ? responseError
-                    : null;
+            final responseCode = decodedBody['code'];
             if (responseCode is String && responseCode.isNotEmpty) {
               errorCode = responseCode;
             }
@@ -222,10 +214,6 @@ class AppHttpClient {
     }
 
     throw const NetworkException('The network request could not be completed.');
-  }
-
-  static bool _looksLikeStableErrorCode(String value) {
-    return RegExp(r'^[A-Z][A-Z0-9_]+$').hasMatch(value);
   }
 
   /// Close the HTTP client

--- a/rythmrun_frontend_flutter/lib/core/utils/error_handler.dart
+++ b/rythmrun_frontend_flutter/lib/core/utils/error_handler.dart
@@ -1,12 +1,18 @@
-import 'dart:convert';
 import 'dart:io';
 import 'package:http/http.dart' as http;
+import '../network/auth_failures.dart';
 import '../network/http_client.dart';
 import '../config/app_config.dart';
 
 class ErrorHandler {
   /// Converts any exception to a user-friendly error message
   static String getErrorMessage(dynamic exception) {
+    // Typed session failures from the auth coordinator already carry a curated,
+    // user-facing message keyed by their reason — surface it directly.
+    if (exception is AuthSessionFailure) {
+      return exception.message;
+    }
+
     String message = _readableMessage(exception);
 
     if (exception is HttpStatusException) {
@@ -48,6 +54,17 @@ class ErrorHandler {
           return 'Incorrect password. Account deletion cancelled.';
         case 'ACCOUNT_DELETION_GOOGLE_INVALID':
           return 'Google authentication could not be verified. Account deletion cancelled.';
+        case 'AUTH_USERNAME_TAKEN':
+          return 'This email is already registered. Please sign in instead.';
+        case 'AUTH_PASSWORD_INVALID':
+          return 'Incorrect current password. Please try again.';
+        case 'AUTH_PASSWORD_UNAVAILABLE':
+          return 'This account uses Google sign-in and has no password to change.';
+        case 'AUTH_USER_NOT_FOUND':
+          // Thrown from the same change-password/delete/profile flows as the
+          // arms above (e.g. the account was removed under a still-valid access
+          // token); a generic 404 "resource not found" reads as a bug there.
+          return 'Your account could not be found. Please sign in again.';
       }
     }
 
@@ -115,34 +132,10 @@ class ErrorHandler {
       return 'Connection timeout. Please check your internet connection and try again.';
     }
 
-    // Handle backend validation errors
-    if (message.contains('Validation failed:')) {
-      return _parseValidationError(message);
-    }
-
-    // Handle authentication errors
-    if (message.contains('UnauthorizedException') ||
-        message.contains('Authentication required')) {
-      return 'Please log in to continue.';
-    }
-
-    if (message.contains('Invalid credentials') ||
-        message.contains('Invalid username or password')) {
-      return 'Invalid email or password. Please try again.';
-    }
-
-    // Handle other specific errors
-    if (message.contains('Username already exists')) {
-      return 'This email is already registered';
-    } else if (message.contains('User not found')) {
-      return 'User not found';
-    } else if (message.contains('Registration failed')) {
-      return message;
-    } else if (message.contains('Login failed')) {
-      return 'Login failed. Please try again.';
-    } else {
-      return message;
-    }
+    // Unmapped errors degrade to the readable message. Backend errors now carry
+    // a stable `code` handled by the switch above; the old string-matching arms
+    // (and the `Validation failed:` JSON parser) are gone.
+    return message;
   }
 
   /// The human-readable text carried by an exception.
@@ -169,116 +162,5 @@ class ErrorHandler {
     // message field; the checks further down deliberately match on their
     // `toString()` text, so keep the existing derivation for them.
     return exception.toString().replaceAll('Exception: ', '');
-  }
-
-  static String _parseValidationError(String errorMessage) {
-    try {
-      // Extract JSON part from the message
-      final jsonStart = errorMessage.indexOf('[');
-      final jsonEnd = errorMessage.lastIndexOf(']') + 1;
-
-      if (jsonStart == -1 || jsonEnd == 0) {
-        return 'Please check your input and try again';
-      }
-
-      final jsonString = errorMessage.substring(jsonStart, jsonEnd);
-      final List<dynamic> validationErrors = json.decode(jsonString);
-
-      final errorMessages = <Map<String, dynamic>>[];
-
-      for (final error in validationErrors) {
-        if (error is Map<String, dynamic>) {
-          final property = error['property'] as String?;
-          final constraints = error['constraints'] as Map<String, dynamic>?;
-
-          if (constraints != null) {
-            for (final constraint in constraints.values) {
-              final message = _friendlyValidationMessage(
-                property,
-                constraint.toString(),
-              );
-              final priority = _getErrorPriority(
-                property,
-                constraint.toString(),
-              );
-              errorMessages.add({'message': message, 'priority': priority});
-            }
-          }
-        }
-      }
-
-      // Sort by priority (lower number = higher priority)
-      errorMessages.sort((a, b) => a['priority'].compareTo(b['priority']));
-      final sortedMessages =
-          errorMessages.map((e) => e['message'] as String).toList();
-
-      if (sortedMessages.isEmpty) {
-        return 'Please check your input and try again';
-      } else if (sortedMessages.length == 1) {
-        return sortedMessages.first;
-      } else {
-        // Multiple errors - show up to 3 most important ones
-        final limitedErrors = sortedMessages.take(3).toList();
-        return '• ${limitedErrors.join('\n• ')}';
-      }
-    } catch (e) {
-      return 'Please check your input and try again';
-    }
-  }
-
-  static String _friendlyValidationMessage(
-    String? property,
-    String constraint,
-  ) {
-    // Convert backend validation messages to user-friendly ones
-    switch (property) {
-      case 'password':
-        if (constraint.contains('longer than or equal to 8')) {
-          return 'Password must be at least 8 characters long';
-        } else if (constraint.contains('must contain')) {
-          return 'Password must contain uppercase, lowercase, number and special character';
-        }
-        return 'Password requirements not met';
-
-      case 'username':
-        if (constraint.contains('must be an email')) {
-          return 'Please enter a valid email address';
-        } else if (constraint.contains('should not be empty')) {
-          return 'Email is required';
-        }
-        return 'Please enter a valid email';
-
-      case 'firstname':
-        return 'First name is required';
-
-      case 'lastname':
-        return 'Last name is required';
-
-      default:
-        return constraint;
-    }
-  }
-
-  static int _getErrorPriority(String? property, String constraint) {
-    // Lower number = higher priority (shows first)
-
-    // Required field errors are most critical
-    if (constraint.contains('should not be empty') ||
-        constraint.contains('is required')) {
-      return 1;
-    }
-
-    // Format validation errors by field importance
-    switch (property) {
-      case 'username': // Email field
-        return 2;
-      case 'password':
-        return 3;
-      case 'firstname':
-      case 'lastname':
-        return 4;
-      default:
-        return 5;
-    }
   }
 }

--- a/rythmrun_frontend_flutter/lib/presentation/features/settings/providers/change_password_provider.dart
+++ b/rythmrun_frontend_flutter/lib/presentation/features/settings/providers/change_password_provider.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/di/injection_container.dart';
+import '../../../../core/network/auth_failures.dart';
+import '../../../../core/utils/error_handler.dart';
 import '../../../../domain/usecases/change_password_usecase.dart';
 import '../models/change_password_state.dart';
 
@@ -22,10 +24,22 @@ class ChangePasswordNotifier extends StateNotifier<ChangePasswordState> {
       );
       state = state.copyWith(isLoading: false, isSuccess: true);
       return response.message; // Return success message
+    } on AuthSessionFailure catch (e) {
+      // A dead/expired session surfaces its curated message; the coordinator has
+      // already emitted the invalidation signal that drives the global logout.
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: ErrorHandler.getErrorMessage(e),
+      );
+      return null;
     } catch (e) {
-      final errorMessage = e.toString().replaceFirst('Exception: ', '');
-      state = state.copyWith(isLoading: false, errorMessage: errorMessage);
-      return null; // Return null on error
+      // Stable backend codes (e.g. AUTH_PASSWORD_INVALID) render curated text via
+      // ErrorHandler — never a raw toString() with the class name welded on.
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: ErrorHandler.getErrorMessage(e),
+      );
+      return null;
     }
   }
 

--- a/rythmrun_frontend_flutter/test/core/network/http_client_test.dart
+++ b/rythmrun_frontend_flutter/test/core/network/http_client_test.dart
@@ -6,12 +6,12 @@ import 'package:http/testing.dart';
 import 'package:rythmrun_frontend_flutter/core/network/http_client.dart';
 
 void main() {
-  test('reads the backend error field as the stable auth code', () async {
+  test('reads the backend stable code field', () async {
     final client = AppHttpClient(
       client: MockClient(
         (_) async => http.Response(
           jsonEncode(<String, Object>{
-            'error': 'AUTH_ACCESS_INVALID',
+            'code': 'AUTH_ACCESS_INVALID',
             'message': 'Authentication is required',
             'statusCode': 401,
           }),
@@ -35,12 +35,43 @@ void main() {
     );
   });
 
+  test('ignores a legacy error field — the code fallback is gone', () async {
+    // Phase 4 dropped the `error`-field heuristic: a body that carries only the
+    // old `error` key yields no stable code, so nothing keeps the client and a
+    // backend that still emitted `error` accidentally compatible.
+    final client = AppHttpClient(
+      client: MockClient(
+        (_) async => http.Response(
+          jsonEncode(<String, Object>{
+            'error': 'AUTH_ACCESS_INVALID',
+            'message': 'Authentication is required',
+          }),
+          401,
+        ),
+      ),
+    );
+    addTearDown(client.close);
+
+    await expectLater(
+      client.get('https://example.test/api/users/me', maxRetries: 0),
+      throwsA(
+        isA<UnauthorizedException>()
+            .having((error) => error.code, 'code', isNull)
+            .having(
+              (error) => error.message,
+              'message',
+              'Authentication is required',
+            ),
+      ),
+    );
+  });
+
   test('classifies every 5xx response as a server failure', () async {
     final client = AppHttpClient(
       client: MockClient(
         (_) async => http.Response(
           jsonEncode(<String, Object>{
-            'error': 'AUTH_SERVICE_UNAVAILABLE',
+            'code': 'AUTH_SERVICE_UNAVAILABLE',
             'message': 'Authentication service is temporarily unavailable',
             'retryable': true,
           }),

--- a/rythmrun_frontend_flutter/test/core/utils/error_handler_auth_test.dart
+++ b/rythmrun_frontend_flutter/test/core/utils/error_handler_auth_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:rythmrun_frontend_flutter/core/network/auth_failures.dart';
 import 'package:rythmrun_frontend_flutter/core/network/http_client.dart';
 import 'package:rythmrun_frontend_flutter/core/utils/error_handler.dart';
 
@@ -142,4 +143,49 @@ void main() {
     expect(message, isNot(contains('SocketException')));
     expect(message.toLowerCase(), contains('connect'));
   });
+
+  test('curates the change-password and register error family by code', () {
+    expect(
+      ErrorHandler.getErrorMessage(
+        HttpStatusException(409, 'x', code: 'AUTH_USERNAME_TAKEN'),
+      ),
+      contains('already registered'),
+    );
+    expect(
+      ErrorHandler.getErrorMessage(
+        UnauthorizedException('x', code: 'AUTH_PASSWORD_INVALID'),
+      ),
+      contains('Incorrect current password'),
+    );
+    expect(
+      ErrorHandler.getErrorMessage(
+        HttpStatusException(400, 'x', code: 'AUTH_PASSWORD_UNAVAILABLE'),
+      ),
+      contains('Google sign-in'),
+    );
+  });
+
+  test('curates AUTH_USER_NOT_FOUND instead of a generic 404', () {
+    // A 404 maps to NotFoundException; without the arm it would read
+    // 'The requested resource was not found.' on a change-password screen.
+    final message = ErrorHandler.getErrorMessage(
+      NotFoundException('User not found', code: 'AUTH_USER_NOT_FOUND'),
+    );
+
+    expect(message, 'Your account could not be found. Please sign in again.');
+    expect(message, isNot(contains('resource was not found')));
+  });
+
+  test(
+    'surfaces a typed session failure without welding on the class name',
+    () {
+      final message = ErrorHandler.getErrorMessage(
+        const AuthSessionUnavailable(AuthSessionUnavailableReason.offlineMode),
+      );
+
+      expect(message, 'This action needs an internet connection.');
+      expect(message, isNot(contains('AuthSessionUnavailable')));
+      expect(message, isNot(contains('AUTH_OFFLINE_MODE')));
+    },
+  );
 }

--- a/rythmrun_frontend_flutter/test/data/datasources/auth_remote_datasource_test.dart
+++ b/rythmrun_frontend_flutter/test/data/datasources/auth_remote_datasource_test.dart
@@ -106,7 +106,7 @@ void main() {
         client: MockClient(
           (_) async => http.Response(
             jsonEncode(<String, Object>{
-              'error': 'AUTH_INVALID_CREDENTIALS',
+              'code': 'AUTH_INVALID_CREDENTIALS',
               'message': 'Invalid username or password',
             }),
             401,


### PR DESCRIPTION
…ent messages (Phase 4)

Backend error responses now carry the stable code in `code` and drop the legacy `error` field entirely — across every emitter the client reads (user.controller sendError, auth + rate-limit middleware, activity-image controller); activity.controller already used `code`. `retryable` added to the account-deletion envelope.

Client reads `code` only (deletes the `_looksLikeStableErrorCode` heuristic and the `error` fallback). ErrorHandler gains an AuthSessionFailure branch and curated arms for the change-password/register family (AUTH_USERNAME_TAKEN, AUTH_PASSWORD_INVALID, AUTH_PASSWORD_UNAVAILABLE, AUTH_USER_NOT_FOUND); the dead string-matching block and the unreachable validation parser are deleted. change_password_provider routes through ErrorHandler instead of toString()-stripping.

Verified against a real Postgres: backend 513/513, Flutter 352, analyzer 9.