### PR TITLE
feat(auth): core hardening — reset-token kill, verify purpose, login …

### DIFF
--- a/RythmRun_backend_nodejs/src/__tests__/user-auth.service.test.ts
+++ b/RythmRun_backend_nodejs/src/__tests__/user-auth.service.test.ts
@@ -10,6 +10,7 @@ jest.unstable_mockModule('bcrypt', () => ({
 
 const bcrypt = await import('bcrypt');
 const { UserService } = await import('../services/user.service.js');
+const { googleAuthUnavailableError } = await import('../errors/auth.error.js');
 
 const user = {
   id: 7,
@@ -73,6 +74,7 @@ function harness() {
       upsert: jest.fn().mockResolvedValue({}),
       findUnique: jest.fn().mockResolvedValue(null),
       updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
     },
   };
   const prisma = {
@@ -175,6 +177,7 @@ describe('UserService authentication lifecycle', () => {
     transaction.verificationToken.findUnique.mockResolvedValueOnce({
       userId: user.id,
       tokenDigest: 'digest',
+      purpose: 'EMAIL_VERIFICATION',
       consumedAt: null,
       expiresAt: new Date(Date.now() + 60_000),
     });
@@ -193,6 +196,7 @@ describe('UserService authentication lifecycle', () => {
     const { service, transaction } = harness();
     transaction.verificationToken.findUnique.mockResolvedValueOnce({
       userId: user.id,
+      purpose: 'EMAIL_VERIFICATION',
       consumedAt: new Date(),
       expiresAt: new Date(Date.now() + 60_000),
     });
@@ -569,6 +573,14 @@ describe('UserService authentication lifecycle', () => {
     expect(
       authSessions.revokeAllUserSessionsInTransaction,
     ).toHaveBeenCalledWith(transaction, verifiedOwner.id);
+    // B2: linking Google drops any outstanding password-reset capability.
+    expect(transaction.verificationToken.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId: verifiedOwner.id,
+        purpose: 'PASSWORD_RESET',
+        consumedAt: null,
+      },
+    });
     expect(transaction.user.create).not.toHaveBeenCalled();
     expect(authSessions.issueSessionInTransaction).toHaveBeenCalledWith(
       transaction,
@@ -651,7 +663,9 @@ describe('UserService authentication lifecycle', () => {
       }),
     ).rejects.toMatchObject({ code: 'AUTH_INVALID_CREDENTIALS' });
 
-    expect(bcrypt.compare).not.toHaveBeenCalled();
+    // B4: the password-less branch still runs one bcrypt comparison (against a
+    // dummy hash) so it cannot be timed apart from a wrong-password rejection.
+    expect(bcrypt.compare).toHaveBeenCalledTimes(1);
   });
 
   it('updates the password and revokes every session in one transaction', async () => {
@@ -709,5 +723,69 @@ describe('UserService authentication lifecycle', () => {
 
     expect(bcrypt.compare).not.toHaveBeenCalled();
     expect(authSessions.withSerializableTransaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wrong-purpose token on the verify-email path (B3)', async () => {
+    const { service, transaction } = harness();
+    transaction.verificationToken.findUnique.mockResolvedValueOnce({
+      userId: user.id,
+      purpose: 'PASSWORD_RESET',
+      consumedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    await expect(service.verifyEmail('reset-token')).rejects.toMatchObject({
+      code: 'AUTH_VERIFICATION_TOKEN_INVALID',
+    });
+    // A cross-purpose token is rejected before it can be consumed or verify.
+    expect(transaction.verificationToken.updateMany).not.toHaveBeenCalled();
+    expect(transaction.user.update).not.toHaveBeenCalled();
+  });
+
+  it('deletes an outstanding reset token when the password changes (B2)', async () => {
+    const { service, prisma, transaction } = harness();
+    prisma.user.findUnique.mockResolvedValue(user);
+    jest.mocked(bcrypt.compare).mockResolvedValue(true as never);
+    jest.mocked(bcrypt.hash).mockResolvedValue('replacement-hash' as never);
+
+    await service.changePassword(user.id, {
+      currentPassword: 'old-password',
+      newPassword: 'new-password',
+    });
+
+    expect(transaction.verificationToken.deleteMany).toHaveBeenCalledWith({
+      where: { userId: user.id, purpose: 'PASSWORD_RESET', consumedAt: null },
+    });
+  });
+
+  it('runs a dummy password comparison for an unknown username (B4)', async () => {
+    const { service, prisma } = harness();
+    prisma.user.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.login({ username: 'ghost@example.com', password: 'guess' }),
+    ).rejects.toMatchObject({ code: 'AUTH_INVALID_CREDENTIALS' });
+
+    // A missing account must cost the same as a wrong password, so a bcrypt
+    // comparison still runs even though there is no stored hash to check.
+    expect(bcrypt.compare).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes a Google outage through deletion as a retryable 503 (C5)', async () => {
+    const { service, prisma, googleIdentityVerifier } = harness();
+    prisma.user.findUnique.mockResolvedValue(googleUser);
+    jest
+      .mocked(googleIdentityVerifier.verifyIdToken)
+      .mockRejectedValueOnce(googleAuthUnavailableError());
+
+    // A transient Google outage must not collapse into a terminal 401 that tells
+    // the user their re-authentication was rejected.
+    await expect(
+      service.deleteAccount(googleUser.id, { googleIdToken: 'id-token' }),
+    ).rejects.toMatchObject({
+      code: 'AUTH_GOOGLE_UNAVAILABLE',
+      statusCode: 503,
+      retryable: true,
+    });
   });
 });

--- a/RythmRun_backend_nodejs/src/services/user.service.ts
+++ b/RythmRun_backend_nodejs/src/services/user.service.ts
@@ -39,6 +39,13 @@ import type { EmailSender } from './email.service.js';
 import type { GoogleIdentityVerifier } from './google-auth.service.js';
 
 const SALT_ROUNDS = 10;
+// A fixed bcrypt hash at the same cost (SALT_ROUNDS) as real passwords. The
+// no-password login branch compares against it so a missing or password-less
+// account spends the same time as a wrong-password check — denying a
+// username-enumeration timing side channel. It is not a secret: no real
+// password hashes to it. Keep the cost in sync with SALT_ROUNDS.
+const DUMMY_PASSWORD_HASH =
+  '$2b$10$mkq4/q4aL7QBg1TKcA.Z4.m8OSHc1JSbps2CoehZBimhzzMAyW5cq';
 const EMAIL_VERIFICATION_PURPOSE = 'EMAIL_VERIFICATION' as const;
 const PASSWORD_RESET_PURPOSE = 'PASSWORD_RESET' as const;
 
@@ -174,6 +181,12 @@ export class UserService {
           return 'invalid' as const;
         }
 
+        // A token minted for a different purpose (e.g. PASSWORD_RESET) must
+        // never verify an email — reject before consuming or reading the owner.
+        if (token.purpose !== EMAIL_VERIFICATION_PURPOSE) {
+          return 'invalid' as const;
+        }
+
         if (token.consumedAt !== null) {
           const owner = await transaction.user.findUnique({
             where: { id: token.userId },
@@ -187,6 +200,7 @@ export class UserService {
         const consumed = await transaction.verificationToken.updateMany({
           where: {
             tokenDigest,
+            purpose: EMAIL_VERIFICATION_PURPOSE,
             consumedAt: null,
             expiresAt: { gt: now },
           },
@@ -334,6 +348,7 @@ export class UserService {
         const consumed = await transaction.verificationToken.updateMany({
           where: {
             tokenDigest,
+            purpose: PASSWORD_RESET_PURPOSE,
             consumedAt: null,
             expiresAt: { gt: now },
           },
@@ -450,6 +465,9 @@ export class UserService {
       where: { username },
     });
     if (user === null || user.password === null) {
+      // Spend the same time as a real password check so a missing or
+      // password-less account is not faster to reject (B4: no enumeration).
+      await bcrypt.compare(loginDto.password, DUMMY_PASSWORD_HASH);
       throw invalidCredentialsError();
     }
 
@@ -537,6 +555,15 @@ export class UserService {
                   transaction,
                   emailOwner.id,
                 );
+                // Linking a Google identity is a credential change like a
+                // password change, so drop any outstanding reset capability.
+                await transaction.verificationToken.deleteMany({
+                  where: {
+                    userId: emailOwner.id,
+                    purpose: PASSWORD_RESET_PURPOSE,
+                    consumedAt: null,
+                  },
+                });
                 return this.authSessions.issueSessionInTransaction(
                   transaction,
                   { ...emailOwner, googleSubject: identity.subject },
@@ -641,6 +668,16 @@ export class UserService {
           transaction,
           userId,
         );
+        // A new password invalidates any outstanding reset capability: an
+        // unconsumed PASSWORD_RESET token issued before the change must not
+        // remain usable afterward.
+        await transaction.verificationToken.deleteMany({
+          where: {
+            userId,
+            purpose: PASSWORD_RESET_PURPOSE,
+            consumedAt: null,
+          },
+        });
       },
     );
   }
@@ -718,6 +755,15 @@ export class UserService {
         }
       } catch (error) {
         if (error instanceof AccountDeletionServiceError) throw error;
+        // A genuine Google outage (503, retryable) must pass through rather than
+        // collapse into a terminal 401 — the caller should retry, not be told
+        // their re-authentication was rejected.
+        if (
+          error instanceof AuthApplicationError &&
+          error.code === 'AUTH_GOOGLE_UNAVAILABLE'
+        ) {
+          throw error;
+        }
         throw accountDeletionGoogleInvalidError();
       }
     }

--- a/docs/_engineering/auth-hardening/MASTER-PLAN.md
+++ b/docs/_engineering/auth-hardening/MASTER-PLAN.md
@@ -4,7 +4,7 @@ published: false
 
 # Auth Hardening & Tunable Timing — Master Plan
 
-**Status:** Phases 0, 1, 3, 4 done · **Phase 2 (M1 grace window) reverted** — broken on real PostgreSQL, restored strict reuse detection · Next: Phase 5 · **Owner:** maintainer · **Created:** 2026-08-11
+**Status:** Phases 0, 1, 3, 4, 5 done · **Phase 2 (M1 grace window) reverted** — broken on real PostgreSQL, restored strict reuse detection · Next: Phase 6 (privacy follow-ups + retire this plan) · **Owner:** maintainer · **Created:** 2026-08-11
 **Source:** auth + refresh audit (16 confirmed findings, 1 plausible, 2 refuted)
 **Relationship to the improvement program:** this is IP-2 follow-up work. It does
 not replace `IP-2-auth-account-privacy.md`; when a phase here lands, its evidence
@@ -646,10 +646,11 @@ Legend: `[ ]` pending · `[~]` in progress · `[x]` done
 - [x] **P1** stable code moved from `error` → `code` and `error` dropped **in every emitter the client reads**, not just `user.controller.ts`: also `auth.middleware.ts` (incl. the load-bearing `AUTH_ACCESS_INVALID` the coordinator branches on), `rate-limit.middleware.ts`, and `activity-image.controller.ts` (`activity.controller.ts` already emitted `code`). Client `http_client.dart` reads `code` only; `_looksLikeStableErrorCode` + the `error` fallback deleted. `retryable` added to the deletion envelope (`AccountDeletionServiceError` gained a `retryable = false` field for Phase 5's Google-503 case). Boundary test asserts every auth error carries a well-formed `code` and no `error` key; a client test locks that a legacy `error`-only body yields no code.
 
 ### Phase 5 — Auth core hardening
-- [ ] **B2** reset tokens killed on password change
-- [ ] **B3** `verifyEmail` purpose check
-- [ ] **B4** login timing flattened
-- [ ] **C5** Google 503 passes through deletion
+- [x] **B2** unconsumed `PASSWORD_RESET` tokens deleted in the same transaction on `changePassword` **and** the Google auto-link (both are credential changes that already revoke sessions), so an outstanding reset token cannot outlive them.
+- [x] **B3** `verifyEmail` rejects a token whose `purpose !== EMAIL_VERIFICATION` before consuming, and the guarded consume `updateMany` carries the `purpose`. Made the `resetPassword` consume symmetric (`purpose: PASSWORD_RESET` in its `updateMany`) so both consume paths encode their full precondition.
+- [x] **B4** the no-password login branch (unknown user or Google-only account) runs one `bcrypt.compare` against a fixed cost-10 `DUMMY_PASSWORD_HASH` before rejecting, so it cannot be timed apart from a wrong-password rejection (username-enumeration side channel closed).
+- [x] **C5** `deleteAccount` rethrows a genuine Google outage (`AUTH_GOOGLE_UNAVAILABLE`, 503, retryable) instead of collapsing it into a terminal 401 — pairs with the `retryable` field added to the deletion envelope in Phase 4. A genuinely invalid token still returns 401.
+- [x] New service tests for each (B2 change-password + auto-link deletion, B3 wrong-purpose rejection, B4 dummy-compare on unknown user + Google-only, C5 503 pass-through) → backend **517**.
 
 ### Phase 6 — Privacy follow-ups
 - [ ] **D3** Google sign-out on forced loss
@@ -704,7 +705,8 @@ failed-flight eviction, A4 avatar replay policy) → Flutter 348. Phase 4 (error
 contract) adds a backend boundary test → **513 passed / 513 total** CI-equivalent
 (506 / 7 skipped / 513 local) and client tests locking the removed `error`
 fallback, the new code arms, and the `AuthSessionFailure` branch → **Flutter 352**;
-analyzer holds at 9.)
+analyzer holds at 9. Phase 5 (auth hardening) adds four service tests →
+**517 passed / 517 total** CI-equivalent, 510 / 7 skipped / 517 local.)
 
 **Four known traps** (from `CLAUDE.md`, repeated because they cost real time):
 1. Use `npm test`, never `npx jest` — the suite is native ESM.


### PR DESCRIPTION
…timing, delete 503 (Phase 5)

B2: changePassword and the Google auto-link delete unconsumed PASSWORD_RESET tokens in the same transaction, so an outstanding reset token cannot survive a credential change.

B3: verifyEmail rejects a token whose purpose != EMAIL_VERIFICATION before consuming it, and both consume paths (verify + reset) carry the purpose in their guarded updateMany.

B4: the no-password login branch (unknown user or Google-only account) runs one bcrypt comparison against a fixed cost-10 dummy hash before rejecting, flattening timing against username enumeration.

C5: deleteAccount rethrows a genuine Google outage (AUTH_GOOGLE_UNAVAILABLE, 503, retryable) instead of collapsing it into a terminal 401.

New service tests for each fix. Verified against a real Postgres: backend 517/517.